### PR TITLE
ci: add configuration for Read the Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ tf_pwa/version.py
 *.gv
 *.root
 !.github/**/*.yml
+!.readthedocs.yml
 !.vscode/*.json
 !environment.yml
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,17 @@
+version: 2
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: false
+
+formats:
+  - epub
+  - htmlzip
+  - pdf
+
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .[doc]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 # A Partial Wave Analysis program using Tensorflow
 
+[![Documentation build status](https://readthedocs.org/projects/tf-pwa/badge/?version=latest)](https://tf-pwa.readthedocs.io)
 [![CI status](https://github.com/jiangyi15/tf-pwa/workflows/CI/badge.svg)](https://github.com/jiangyi15/tf-pwa/actions?query=branch%3Adev+workflow%3ACI)
 [![Test coverage](https://codecov.io/gh/jiangyi15/tf-pwa/branch/dev/graph/badge.svg)](https://codecov.io/gh/jiangyi15/tf-pwa)
 [![conda cloud](https://anaconda.org/jiangyi15/tf-pwa/badges/version.svg)](https://anaconda.org/jiangyi15/tf-pwa)

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     matplotlib
+    numpy
     opt_einsum
     PyYAML
     scipy


### PR DESCRIPTION
The docs on RTD are currently failing -- not sure why. Hope this config file will fix it, it is recommended by RTD
https://docs.readthedocs.io/en/stable/config-file/v2.html