### PR TITLE
feat: support to add p -> -p trans for charge conjugation process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 [Full Changelog](https://github.com/jiangyi15/tf-pwa/compare/v0.1.5...HEAD)
 
+**<font color=red>Numeric</font>**
+
+- Support parity transfomation, for charge conjugation process. The old method
+  is still aviable for `cp_trans: False`
+  [#53](https://github.com/jiangyi15/tf-pwa/pull/53)
+
+**Changed**
+
+- Force hessian matrix positive defined by adding some value for eigen value.
+  [#52](https://github.com/jiangyi15/tf-pwa/pull/52)
+
 ## [v0.1.5](https://github.com/jiangyi15/tf-pwa/tree/v0.1.5) (2021-07-25)
 
 [Full Changelog](https://github.com/jiangyi15/tf-pwa/compare/v0.1.4...v0.1.5)

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -35,6 +35,8 @@ data:
   # cached data file
   # cached_data: "data/all_data.npy"
   # data_charge: ["data/data4600_cc.dat"] # charge conjugation condition same as weight
+  # cp_trans: True # when used charge conjugation as above, this do p -> -p for charge conjugation process.
+
 
 # `decay` describe the decay structure, each node can be a list of particle name
 decay:

--- a/tf_pwa/cal_angle.py
+++ b/tf_pwa/cal_angle.py
@@ -483,8 +483,13 @@ def add_relative_momentum(data: dict):
     return data
 
 
+def parity_trans(p, charges):
+    charges = charges[: p.shape[0], None]
+    return tf.where(charges > 0, p, LorentzVector.neg(p))
+
+
 def prepare_data_from_decay(
-    fnames, decs, particles=None, dtype=None, **kwargs
+    fnames, decs, particles=None, dtype=None, charges=None, **kwargs
 ):
     """
     Transform 4-momentum data in files for the amplitude model automatically via DecayGroup.
@@ -500,6 +505,8 @@ def prepare_data_from_decay(
     if particles is None:
         particles = sorted(decs.outs)
     p = load_dat_file(fnames, particles, dtype=dtype)
+    if charges is not None:
+        p = {k: parity_trans(v, charges) for k, v in p.items()}
     data = cal_angle_from_momentum(p, decs, **kwargs)
     return data
 

--- a/tf_pwa/config_loader/data.py
+++ b/tf_pwa/config_loader/data.py
@@ -141,7 +141,7 @@ class SimpleData:
         center_mass = self.dic.get("center_mass", True)
         r_boost = self.dic.get("r_boost", False)
         random_z = self.dic.get("random_z", False)
-        cp_trans = self.dic.get("cp_trans", False)
+        cp_trans = self.dic.get("cp_trans", True)
         charges = None if charge is None else self.load_weight_file(charge)
         data = prepare_data_from_decay(
             files,

--- a/tf_pwa/config_loader/data.py
+++ b/tf_pwa/config_loader/data.py
@@ -141,6 +141,8 @@ class SimpleData:
         center_mass = self.dic.get("center_mass", True)
         r_boost = self.dic.get("r_boost", False)
         random_z = self.dic.get("random_z", False)
+        cp_trans = self.dic.get("cp_trans", False)
+        charges = None if charge is None else self.load_weight_file(charge)
         data = prepare_data_from_decay(
             files,
             self.decay_struct,
@@ -148,6 +150,7 @@ class SimpleData:
             center_mass=center_mass,
             r_boost=r_boost,
             random_z=random_z,
+            charges=charges if cp_trans else None,
         )
         if weights is not None:
             if isinstance(weights, float):
@@ -162,8 +165,11 @@ class SimpleData:
                     "weight format error: {}".format(type(weights))
                 )
         if charge is not None:
-            charges = self.load_weight_file(charge)
-            data["charge_conjugation"] = charges[: data_shape(data)]
+            if cp_trans:
+                data["charge_conjugation"] = np.ones((data_shape(data),))
+                data["charge_conjugation2"] = charges[: data_shape(data)]
+            else:
+                data["charge_conjugation"] = charges[: data_shape(data)]
         else:
             data["charge_conjugation"] = np.ones((data_shape(data),))
         return data

--- a/tf_pwa/config_loader/tests/test_data.py
+++ b/tf_pwa/config_loader/tests/test_data.py
@@ -31,3 +31,8 @@ def test_load_data(gen_toy):
     data = load_data_mode(data_file, dec, "simple")
     w2 = data.get_data("bg")["weight"]
     assert np.allclose(w1, w2)
+
+    data = load_data_mode({**data_file, "cp_trans": True}, dec, "simple")
+    np.savetxt("toy_data/test_charge.dat", np.random.random(w2.shape) > 0.5)
+    p1 = data.load_data("toy_data/bg.dat", charge="toy_data/test_charge.dat")
+    assert np.sum(p1["charge_conjugation"] - 1) == 0


### PR DESCRIPTION
A cp transformation may keep the same amplitude. For charge conjugation process, a P transform can be used for the amplitude calculation by using
```
data:
     cp_trans: True
```