### PR TITLE
identical particle swaping and other basic change

### DIFF
--- a/tf_pwa/cal_angle.py
+++ b/tf_pwa/cal_angle.py
@@ -581,7 +581,6 @@ def identical_particles_swap(id_particles):
     ret = []
     for i in id_particles:
         ret.append(list(itertools.permutations(i)))
-    print(ret)
     for i in itertools.product(*ret):
         yield i
 

--- a/tf_pwa/config_loader/data.py
+++ b/tf_pwa/config_loader/data.py
@@ -165,8 +165,8 @@ class SimpleData:
         charges = None if charge is None else self.load_weight_file(charge)
         p4 = self.load_p4(files)
         cp_trans = self.dic.get("cp_trans", True)
-        if cp_trans and charges:
-            p = {k: parity_trans(v, charges) for k, v in p.items()}
+        if cp_trans and charges is not None:
+            p4 = {k: parity_trans(v, charges) for k, v in p4.items()}
         data = self.cal_angle(p4)
         if weights is not None:
             if isinstance(weights, float):
@@ -181,11 +181,7 @@ class SimpleData:
                     "weight format error: {}".format(type(weights))
                 )
         if charge is not None:
-            if cp_trans:
-                data["charge_conjugation"] = np.ones((data_shape(data),))
-                data["charge_conjugation2"] = charges[: data_shape(data)]
-            else:
-                data["charge_conjugation"] = charges[: data_shape(data)]
+            data["charge_conjugation"] = charges[: data_shape(data)]
         else:
             data["charge_conjugation"] = np.ones((data_shape(data),))
         return data

--- a/tf_pwa/config_loader/decay_config.py
+++ b/tf_pwa/config_loader/decay_config.py
@@ -7,6 +7,7 @@ import yaml
 from tf_pwa.amp import (
     DecayChain,
     DecayGroup,
+    HelicityDecay,
     get_decay,
     get_particle,
     split_particle_type,
@@ -22,7 +23,34 @@ def set_min_max(dic, name, name_min, name_max):
         )
 
 
+def decay_chain_cut_ls(decay):
+    for i in decay:
+        if isinstance(i, HelicityDecay):
+            if len(i.get_ls_list()) == 0:
+                return False, f"{i} ls not aviable {i.get_ls_list()}"
+    return True, ""
+
+
+def decay_chain_cut_mass(decay):
+    for i in decay:
+        if isinstance(i, HelicityDecay):
+            if i.core.mass is None or any([j.mass is None for j in i.outs]):
+                continue
+            # print(i, i.core.mass, [j.mass for j in i.outs])
+            if i.core.mass < sum([j.mass for j in i.outs]):
+                return (
+                    False,
+                    f"{i} mass break {i.core.mass} < {[j.mass for j in i.outs]}",
+                )
+    return True, ""
+
+
 class DecayConfig(BaseConfig):
+    decay_chain_cut_list = {
+        "ls_cut": decay_chain_cut_ls,
+        "mass_cut": decay_chain_cut_mass,
+    }
+
     def __init__(self, dic, share_dict={}):
         self.config = dic
         self.decay_chain_config = dic.get("decay_chain", {})
@@ -39,6 +67,7 @@ class DecayConfig(BaseConfig):
             "bw_l": "bw_l",
             "running_width": "running_width",
         }
+        self.cut_list = self.config["data"].get("decay_chain_cut", ["ls_cut"])
         self.decay_key_map = {"model": "model"}
         self.dec = self.decay_item(self.config["decay"])
         (
@@ -57,7 +86,11 @@ class DecayConfig(BaseConfig):
                 self.decay_chain_config,
             )
         )
-        self.decay_struct = DecayGroup(self.get_decay_struct(self.dec))
+        if self.config["data"].get("cp_trans", True):
+            self.disable_allow_cc(self.full_decay)
+        self.decay_struct = DecayGroup(
+            self.get_decay_struct(self.dec, process_cut=False)
+        )
         identical_particles = self.config["data"].get(
             "identical_particles", None
         )
@@ -196,6 +229,28 @@ class DecayConfig(BaseConfig):
             ret[key_map.get(k, k)] = v
         return ret
 
+    def decay_chain_cut(self, decays):
+        ret = []
+        for i in decays:
+            flag = True
+            for name in self.cut_list:
+                f = DecayConfig.decay_chain_cut_list[name]
+                new_flag, msg = f(i)
+                flag = flag and new_flag
+                if not flag:
+                    print(
+                        "remove decay chain",
+                        i,
+                        "by",
+                        name,
+                        "\n\tbecause of",
+                        msg,
+                    )
+                    break
+            if flag:
+                ret.append(i)
+        return ret
+
     def get_decay_struct(
         self,
         decay,
@@ -204,6 +259,7 @@ class DecayConfig(BaseConfig):
         top=None,
         finals=None,
         chain_params={},
+        process_cut=True,
     ):
         """  get decay structure for decay dict"""
         particle_map = particle_map if particle_map is not None else {}
@@ -274,4 +330,12 @@ class DecayConfig(BaseConfig):
             if sorted(DecayChain(i).outs) == sorted(finals):
                 all_params = chain_params.get("$all", {})
                 ret.append(DecayChain(i, **all_params))
+        if process_cut:
+            return self.decay_chain_cut(ret)
         return ret
+
+    def disable_allow_cc(self, decay_group):
+        for decay_chain in decay_group:
+            for decay in decay_chain:
+                if hasattr(decay, "allow_cc"):
+                    decay.allow_cc = False

--- a/tf_pwa/config_loader/decay_config.py
+++ b/tf_pwa/config_loader/decay_config.py
@@ -58,6 +58,12 @@ class DecayConfig(BaseConfig):
             )
         )
         self.decay_struct = DecayGroup(self.get_decay_struct(self.dec))
+        identical_particles = self.config["data"].get(
+            "identical_particles", None
+        )
+        if identical_particles is not None:
+            self.decay_struct.identical_particles = identical_particles
+            self.full_decay.identical_particles = identical_particles
 
     @staticmethod
     def load_config(file_name, share_dict={}):

--- a/tf_pwa/config_loader/tests/test_data.py
+++ b/tf_pwa/config_loader/tests/test_data.py
@@ -33,6 +33,7 @@ def test_load_data(gen_toy):
     assert np.allclose(w1, w2)
 
     data = load_data_mode({**data_file, "cp_trans": True}, dec, "simple")
-    np.savetxt("toy_data/test_charge.dat", np.random.random(w2.shape) > 0.5)
+    charge = np.random.random(w2.shape) > 0.5
+    np.savetxt("toy_data/test_charge.dat", charge)
     p1 = data.load_data("toy_data/bg.dat", charge="toy_data/test_charge.dat")
-    assert np.sum(p1["charge_conjugation"] - 1) == 0
+    assert np.sum(p1["charge_conjugation"] - charge) == 0

--- a/tf_pwa/particle.py
+++ b/tf_pwa/particle.py
@@ -432,25 +432,37 @@ class Decay(BaseDecay):  # add useful methods to BaseDecay
         return ret
 
 
-def split_particle_type(decays):
+def split_particle_type_list(decays):
     """
     Separate initial particle, intermediate particles, final particles in a decay chain.
 
     :param decays: DecayChain
     :return: Set of initial Particle, set of intermediate Particle, set of final Particle
     """
-    core_particles = set()
-    out_particles = set()
+    core_particles = []
+    out_particles = []
 
     for i in decays:
-        core_particles.add(i.core)
+        core_particles.append(i.core)
         for j in i.outs:
-            out_particles.add(j)
+            out_particles.append(j)
 
-    inner = core_particles & out_particles
-    top = core_particles - inner
-    outs = out_particles - inner
+    inner = [
+        i for i in core_particles if i in out_particles
+    ]  # core_particles & out_particles
+    top = [
+        i for i in core_particles if i not in inner
+    ]  # core_particles - inner
+    outs = [
+        i for i in out_particles if i not in inner
+    ]  # out_particles - inner
+    # print(decays, inner, top, outs)
     return top, inner, outs
+
+
+def split_particle_type(decays):
+    top, inner, outs = split_particle_type_list(decays)
+    return set(top), set(inner), set(outs)
 
 
 def split_len(dicts):
@@ -485,7 +497,7 @@ class DecayChain(object):
 
     def __init__(self, chain):
         self.chain = chain
-        top, inner, outs = split_particle_type(chain)
+        top, inner, outs = split_particle_type_list(chain)
         assert len(top) == 1, "top particles must be only one particle"
         self.top = top.pop()
         self.inner = sorted(list(inner))

--- a/tf_pwa/particle.py
+++ b/tf_pwa/particle.py
@@ -828,6 +828,7 @@ class DecayGroup(object):
                 if j not in resonances:
                     resonances.append(j)
         self.resonances = list(resonances)
+        self.identical_particles = []
 
     def __repr__(self):
         return "{}".format(self.chains)


### PR DESCRIPTION
Support identical particle swap momentum in cal_angle.
Add indentical_particles in config.yml:data for example
```
identical_particles: [[a, b]]
```
It means (a and b) are identical particles. Then pa <-> pb angle will be calculated. Amplitude sum over identical particles is supported by basic option. (`cached_amp` is not supported). 

Some basic changes in decay_config to remove some bad decay chain. 
A new option `decay_chain_cut: ["ls_cut", "mass_cut"]` to enable some filter cuts for decay chain.

`cp_trans=True` will make `allow_cc=False` now. 