### PR TITLE
Support for root file input directly

### DIFF
--- a/tf_pwa/config_loader/__init__.py
+++ b/tf_pwa/config_loader/__init__.py
@@ -4,6 +4,7 @@ from .config_loader import (
     PlotParams,
     validate_file_name,
 )
+from .data_root_lhcb import RootData
 from .extra import *
 from .multi_config import MultiConfig
 from .particle_function import ParticleFunction

--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -148,18 +148,6 @@ class ConfigLoader(BaseConfig):
                 new_order.append(i)
         return new_order
 
-    def get_data_mode(self):
-        data_config = self.config.get("data", {})
-        data = data_config.get("data", "")
-        if isinstance(data, str):
-            mode = "single"
-        elif isinstance(data, list):
-            data_i = data[0]
-            if isinstance(data_i, str):
-                return "single"
-            elif isinstance(data_i, list):
-                return "multi"
-
     @functools.lru_cache()
     def get_data(self, idx):
         return self.data.get_data(idx)

--- a/tf_pwa/config_loader/data.py
+++ b/tf_pwa/config_loader/data.py
@@ -56,7 +56,9 @@ def register_data_mode(name=None, f=None):
 def load_data_mode(dic, decay_struct, default_mode="multi", config=None):
     if dic is None:
         dic = {}
-    mode = dic.get("mode", default_mode)
+    mode = dic.get("format", None)
+    if mode is None:
+        mode = dic.get("mode", default_mode)
     return get_config(DATA_MODE)[mode](dic, decay_struct, config=config)
 
 

--- a/tf_pwa/config_loader/data.py
+++ b/tf_pwa/config_loader/data.py
@@ -201,7 +201,11 @@ class SimpleData:
     def process_cp_trans(self, p4, charges):
         cp_trans = self.dic.get("cp_trans", True)
         if cp_trans and charges is not None:
-            p4 = {k: parity_trans(v, charges) for k, v in p4.items()}
+            if self.lazy_call:
+                with tf.device("CPU"):
+                    p4 = {k: parity_trans(v, charges) for k, v in p4.items()}
+            else:
+                p4 = {k: parity_trans(v, charges) for k, v in p4.items()}
         return p4
 
     def load_extra_var(self, n_data, **kwargs):

--- a/tf_pwa/config_loader/data_root_lhcb.py
+++ b/tf_pwa/config_loader/data_root_lhcb.py
@@ -63,7 +63,7 @@ class RootData(MultiData):
             print("uproot < 4 is not support")
             return [None]
         if idx not in self.dic:
-            return [None]
+            return None
         p4 = self.get_p4(idx)
         n_data = [i.shape[0] for i in p4]
         p4 = [list(np.moveaxis(i, 1, 0)) for i in p4]

--- a/tf_pwa/config_loader/data_root_lhcb.py
+++ b/tf_pwa/config_loader/data_root_lhcb.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 
 from tf_pwa.config_loader.data import MultiData, register_data_mode
 from tf_pwa.data import data_mask
-from tf_pwa.root_io import uproot
+from tf_pwa.root_io import uproot, uproot_version
 
 
 def build_matrix(order, matrix):
@@ -59,6 +59,9 @@ class RootData(MultiData):
         return ret
 
     def get_data(self, idx):
+        if uproot_version < 4:
+            print("uproot < 4 is not support")
+            return None
         if idx not in self.dic:
             return None
         p4 = self.get_p4(idx)

--- a/tf_pwa/config_loader/data_root_lhcb.py
+++ b/tf_pwa/config_loader/data_root_lhcb.py
@@ -1,0 +1,139 @@
+import numpy as np
+import sympy
+import tensorflow as tf
+
+from tf_pwa.config_loader.data import MultiData, register_data_mode
+from tf_pwa.data import data_mask
+from tf_pwa.root_io import uproot
+
+
+def build_matrix(order, matrix):
+    if len(order) == 0:
+        yield {}
+    else:
+        idx = order[0]
+        if isinstance(idx, str):
+            for k in matrix[idx]:
+                tmp = {idx: k}
+                for x in build_matrix(order[1:], matrix):
+                    yield {**tmp, **x}
+        elif isinstance(idx, list):
+            for k in zip(*[matrix[i] for i in idx]):
+                tmp = dict(zip(idx, k))
+                for x in build_matrix(order[1:], matrix):
+                    yield {**tmp, **x}
+        else:
+            raise TypeError(f"not supported type {type(idx)}")
+
+
+def touch_var(name, data, var, size, default=1):
+    for i, v, s in zip(data, var, size):
+        if v is None:
+            v = default
+        if isinstance(v, (float, int)):
+            i[name] = v * np.ones(s)
+        else:
+            i[name] = v
+    return data
+
+
+def custom_cond(x, dic, key=None):
+    if key is None:
+        key = list(dic.keys())
+    if len(key) == 0:
+        return np.zeros_like(x)
+    return np.where(x == key[0], dic[key[0]], custom_cond(x, dic, key[1:]))
+
+
+def cut_data(data):
+    mask = data["weight"] != 0
+    return data_mask(data, mask)
+
+
+@register_data_mode("root_lhcb")
+class RootData(MultiData):
+    def create_data(self, p4, **kwargs):
+        ret = self.cal_angle(p4, **kwargs)
+        for k, v in kwargs.items():
+            ret[k] = v
+        return ret
+
+    def get_data(self, idx):
+        if idx not in self.dic:
+            return None
+        p4 = self.get_p4(idx)
+        n_data = [i.shape[0] for i in p4]
+        p4 = [list(np.moveaxis(i, 1, 0)) for i in p4]
+        weight = self.get_weight(idx)
+        ret = [{"p4": i} for i in p4]
+        # touch_var("weight", ret, weight, n_data)
+        # print(idx, weight)
+        # touch_var("charge_conjugation", ret, self.load_var(idx, "_charge"), n_data)
+        for k, v in self.extra_var.items():
+            touch_var(
+                v.get("key", k),
+                ret,
+                self.load_var(idx, "_" + k),
+                n_data,
+                v.get("default", 1),
+            )
+        ret = [cut_data(i) for i in ret]
+        ret = [self.create_data(**i) for i in ret]
+        return ret
+
+    def load_var(self, idx, tail):
+        matrix = self.dic["matrix"]
+        matrix_order = self.dic["matrix_order"]
+        file_name = self.dic[idx]
+
+        ret = []
+
+        custom_function = {
+            "float": lambda x: np.array(x).astype(np.float64),
+            "int": lambda x: np.array(x).astype(np.int32),
+            "cond": custom_cond,
+        }
+
+        for i, file_name_part in enumerate(
+            build_matrix(matrix_order[:-2], matrix)
+        ):
+            expr = self.dic[idx + tail].format(**file_name_part)
+            expr = sympy.simplify(expr)
+            var = list(expr.free_symbols)
+            tmp = {}
+            custom_function["select"] = lambda x: x[i]
+            with uproot.open(file_name.format(**file_name_part)) as t:
+                for name in var:
+                    b = t.get(str(name))
+                    if b is None:
+                        print("not found", name)
+                        continue
+                    tmp[str(name)] = b.array(library="np")
+            ret.append(
+                sympy.lambdify(var, expr, modules=[custom_function, "numpy"])(
+                    **tmp
+                )
+            )
+        return ret
+
+    def get_weight(self, idx):
+        return self.load_var(idx, "_weight")
+
+    def get_p4(self, idx):
+        matrix = self.dic["matrix"]
+        matrix_order = self.dic["matrix_order"]
+        file_name = self.dic[idx]
+        p4_name = self.dic[idx + "_var"]
+        scale = self.dic.get("unit_scale", 0.001)
+        ret = []
+        for file_name_part in build_matrix(matrix_order[:-2], matrix):
+            tmp = []
+            with uproot.open(file_name.format(**file_name_part)) as t:
+                for pname in build_matrix(matrix_order[-3:], matrix):
+                    tmp.append(
+                        t.get(p4_name.format(**pname)).array(library="np")
+                    )
+            ret.append(
+                scale * np.stack(tmp, axis=-1).reshape((-1, len(tmp) // 4, 4))
+            )
+        return ret

--- a/tf_pwa/config_loader/data_root_lhcb.py
+++ b/tf_pwa/config_loader/data_root_lhcb.py
@@ -61,9 +61,9 @@ class RootData(MultiData):
     def get_data(self, idx):
         if uproot_version < 4:
             print("uproot < 4 is not support")
-            return None
+            return [None]
         if idx not in self.dic:
-            return None
+            return [None]
         p4 = self.get_p4(idx)
         n_data = [i.shape[0] for i in p4]
         p4 = [list(np.moveaxis(i, 1, 0)) for i in p4]

--- a/tf_pwa/config_loader/plot.py
+++ b/tf_pwa/config_loader/plot.py
@@ -685,6 +685,8 @@ def _plot_partial_wave(
 
         for i, name_i, label, curve_style in chain_property:
             weight_i = phsp_dict["MC_{0}_{1}_fit".format(i, name_i)]
+            if np.allclose(weight_i, 0):
+                continue
             hist_i = Hist1D.histogram(
                 phsp_i,
                 weights=weight_i,

--- a/tf_pwa/config_loader/tests/config_root_data.yml
+++ b/tf_pwa/config_loader/tests/config_root_data.yml
@@ -1,0 +1,44 @@
+data:
+  mode: "root_lhcb"
+  dat_order: [D1, D2, K] # same as particle in matrix
+  data: "toy_data/Data_{run}.root:DecayTree0"
+  data_var: "{particle}_{pi}"
+  data_weight: "(float((B_M < 5300)&(B_M > 5260))*1)" # cut and weight formula
+  unit_scale: 0.001 # scale for monmentum
+  data_charge: "B_Q" # formula for var
+  bg: "toy_data/Data_{run}.root:DecayTree0"
+  bg_var: "{particle}_{pi}"
+  bg_weight: "-(float(((B_M > 5320)|(B_M < 5250)))*select((0.35, 0.36)))"
+  bg_charge: "B_Q"
+  phsp: "toy_data/MC_{run}.root:DecayTree0"
+  matrix_order: ["run", "particle", ["pi", "pi2"]] # the last two are only used for p4
+  matrix: # matrix will generate a list of files (and variables for p4)
+    run: ["run1", "run2"]
+    particle: ["D1", "D2", "K"]
+    pi: ["E", "PX", "PY", "PZ"]
+    pi2: ["P_E", "P_X", "P_Y", "P_Z"]
+  phsp_var: "{particle}_TRUE{pi2}"
+  phsp_weight:
+    "cond(year, {{2011: 1.11, 2012: 2.08, 2015: 0.33, 2016: 1.67, 2017: 1.71,
+    2018: 2.19}}) * Effcorr"
+  phsp_charge: "B_Q"
+
+decay:
+  B:
+    - [D1D2, K, p_break: True]
+    - [D1K, D2]
+    - [D2K, D1]
+  D1D2: [D1, D2]
+  D1K: [D1, K]
+  D2K: [D2, K]
+
+particle:
+  $top: B
+  $finals: [D1, D2, K]
+  D1D2: { J: 1, P: -1, mass: 4.04, width: 0.05 }
+  D1K: []
+  D2K: []
+  B: { J: 0, P: -1, mass: 5.28 }
+  D1: { J: 0, P: -1, mass: 1.8 }
+  D2: { J: 0, P: -1, mass: 1.8 }
+  K: { J: 0, P: -1, mass: 0.5 }

--- a/tf_pwa/config_loader/tests/config_root_data.yml
+++ b/tf_pwa/config_loader/tests/config_root_data.yml
@@ -1,5 +1,5 @@
 data:
-  mode: "root_lhcb"
+  format: "root_lhcb"
   dat_order: [D1, D2, K] # same as particle in matrix
   data: "toy_data/Data_{run}.root:DecayTree0"
   data_var: "{particle}_{pi}"

--- a/tf_pwa/config_loader/tests/test_root_data.py
+++ b/tf_pwa/config_loader/tests/test_root_data.py
@@ -1,0 +1,44 @@
+import os
+
+import numpy as np
+import pytest
+
+from tf_pwa import root_io
+from tf_pwa.config_loader import ConfigLoader
+from tf_pwa.phasespace import PhaseSpaceGenerator
+
+this_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.fixture
+def create_fake_data():
+    a = PhaseSpaceGenerator(5280.0, [1800.0, 1800.0, 500.0])
+    p = a.generate(100)
+    p = [i.numpy() for i in p]
+
+    dic = {}
+    for idx_i, i in enumerate(["D1", "D2", "K"]):
+        for idx_j, j in enumerate(["E", "PX", "PY", "PZ"]):
+            dic[f"{i}_{j}"] = p[idx_i][..., idx_j]
+        for idx_j, j in enumerate(["P_E", "P_X", "P_Y", "P_Z"]):
+            dic[f"{i}_TRUE{j}"] = p[idx_i][..., idx_j]
+
+    dic["year"] = np.array([2011, 2012, 2015, 2016, 2017] * 20)
+    dic["Effcorr"] = np.random.random(100) + 0.1
+    dic["B_M"] = np.random.normal(size=100) * 30 + 5280
+    dic["B_Q"] = (np.random.random(100) > 0.5).astype(np.int32) * 2 - 1
+
+    files = [
+        "./toy_data/Data_run1.root",
+        "./toy_data/Data_run2.root",
+        "./toy_data/MC_run1.root",
+        "./toy_data/MC_run2.root",
+    ]
+    os.makedirs("./toy_data/", exist_ok=True)
+    for f in files:
+        root_io.save_dict_to_root(dic, f, "DecayTree")
+
+
+def test_root_data(create_fake_data):
+    config = ConfigLoader(f"{this_dir}/config_root_data.yml")
+    data = config.get_all_data()

--- a/tf_pwa/root_io.py
+++ b/tf_pwa/root_io.py
@@ -16,6 +16,7 @@ except ImportError as e:
         has_uproot = False
         print(e, "you should install `uproot` correctly for using this module")
         uproot_version = 4
+        uproot = None
 
 
 def load_root_data(fnames):


### PR DESCRIPTION
data format option, see full example in  tf_pwa/config_loader/tests/test_root_data.yml
```
data:
    format: root_lhcb
    data: "data.root:tree"
    data_var: "{a}_{b}" # p4 variable, used name in  matrixto build all variable
    data_weight: "x" # formula for variable
    matrix_order: ["a", "b"] 
    matrix:
        a:  ["B", "C", "D"]
        b:  ["E", "PX", "PY", "PZ"]   
    # B_E B_PX B_PY B_PZ
    # C_E C_PX C_PY C_PZ
    # D_E D_PX D_PY D_PZ
```


   
    