### PR TITLE
Lazy file

### DIFF
--- a/tf_pwa/amp/preprocess.py
+++ b/tf_pwa/amp/preprocess.py
@@ -2,7 +2,11 @@ import warnings
 
 import tensorflow as tf
 
-from tf_pwa.cal_angle import CalAngleData, cal_angle_from_momentum
+from tf_pwa.cal_angle import (
+    CalAngleData,
+    cal_angle_from_momentum,
+    parity_trans,
+)
 from tf_pwa.config import create_config, get_config, regist_config, temp_config
 from tf_pwa.data import HeavyCall, data_strip
 
@@ -50,6 +54,9 @@ class BasePreProcessor(HeavyCall):
 
     def __call__(self, x):
         p4 = x["p4"]
+        if self.kwargs.get("cp_trans", False):
+            charges = x.get("extra", {}).get("charge_conjugation", None)
+            p4 = {k: parity_trans(v, charges) for k, v in p4.items()}
         kwargs = {}
         for k in [
             "center_mass",

--- a/tf_pwa/cal_angle.py
+++ b/tf_pwa/cal_angle.py
@@ -559,6 +559,8 @@ def add_relative_momentum(data: dict):
 
 
 def parity_trans(p, charges):
+    if charges is None:
+        return p
     charges = charges[: p.shape[0], None]
     return tf.where(charges > 0, p, LorentzVector.neg(p))
 

--- a/tf_pwa/config_loader/data.py
+++ b/tf_pwa/config_loader/data.py
@@ -17,6 +17,7 @@ from tf_pwa.config import create_config, get_config, regist_config, temp_config
 from tf_pwa.config_loader.decay_config import DecayConfig
 from tf_pwa.data import (
     LazyCall,
+    LazyFile,
     data_index,
     data_shape,
     data_split,
@@ -86,6 +87,10 @@ class SimpleData:
                     self.re_map[v] = k
         self.scale_list = self.dic.get("scale_list", ["bg"])
         self.lazy_call = self.dic.get("lazy_call", False)
+        self.lazy_file = self.dic.get("lazy_file", False)
+        self.cp_trans = self.dic.get("cp_trans", True)
+        if self.lazy_file and self.cp_trans:
+            warnings.warn("use lazy_file with cp_trans")
         center_mass = self.dic.get("center_mass", False)
         r_boost = self.dic.get("r_boost", True)
         random_z = self.dic.get("random_z", True)
@@ -186,7 +191,8 @@ class SimpleData:
 
     def load_p4(self, fnames):
         particles = self.get_dat_order()
-        p = load_dat_file(fnames, particles)
+        mmap_mode = "r" if self.lazy_file else None
+        p = load_dat_file(fnames, particles, mmap_mode=mmap_mode)
         return p
 
     def cal_angle(self, p4, **kwargs):
@@ -195,14 +201,18 @@ class SimpleData:
         charge = kwargs.get("charge_conjugation", None)
         p4 = self.process_cp_trans(p4, charge)
         if self.lazy_call:
-            data = LazyCall(self.preprocessor, {"p4": p4, "extra": kwargs})
+            if self.lazy_file:
+                data = LazyCall(
+                    self.preprocessor, LazyFile({"p4": p4, "extra": kwargs})
+                )
+            else:
+                data = LazyCall(self.preprocessor, {"p4": p4, "extra": kwargs})
         else:
             data = self.preprocessor({"p4": p4, "extra": kwargs})
         return data
 
     def process_cp_trans(self, p4, charges):
-        cp_trans = self.dic.get("cp_trans", True)
-        if cp_trans and charges is not None:
+        if self.cp_trans and charges is not None:
             if self.lazy_call:
                 with tf.device("CPU"):
                     p4 = {k: parity_trans(v, charges) for k, v in p4.items()}

--- a/tf_pwa/tests/config_toy_npy.yml
+++ b/tf_pwa/tests/config_toy_npy.yml
@@ -1,0 +1,42 @@
+data:
+  dat_order: [B, C, D]
+  data: ["toy_data/data_npy.npy"]
+  bg: ["toy_data/bg_npy.npy"]
+  phsp: ["toy_data/PHSP_npy.npy"]
+  lazy_file: True
+  lazy_call: True
+  cached_lazy_call: toy_data/cached2/
+  lazy_prefetch: 0
+  bg_weight: 0.1
+
+decay:
+  A:
+    - [R_BC, D]
+    - [R_BD, C]
+    - [R_CD, B]
+  R_BC: [B, C]
+  R_BD: [B, D]
+  R_CD: [C, D]
+
+particle:
+  $top:
+    A: { J: 1, P: -1, spins: [-1, 1], mass: 4.6 }
+  $finals:
+    B: { J: 1, P: -1, mass: 2.00698 }
+    C: { J: 1, P: -1, mass: 2.01028 }
+    D: { J: 0, P: -1, mass: 0.13957 }
+  R_BC: { J: 1, Par: 1, m0: 4.16, g0: 0.1, params: { mass_range: [4.0, 4.2] } }
+  R_BD: { J: 1, Par: 1, m0: 2.43, g0: 0.3 }
+  R_CD: { J: 1, Par: 1, m0: 2.42, g0: 0.03 }
+
+constrains:
+  particle: null
+  decay: null
+
+plot:
+  config:
+    legend_outside: True
+  mass:
+    R_BC: { display: "$M_{BC}$" }
+    R_BD: { display: "$M_{BD}$" }
+    R_CD: { display: "$M_{CD}$" }

--- a/tf_pwa/tests/test_full.py
+++ b/tf_pwa/tests/test_full.py
@@ -65,8 +65,22 @@ def gen_toy():
 
 
 @pytest.fixture
+def toy_npy(gen_toy):
+    for i in ["data", "bg", "PHSP"]:
+        data = np.loadtxt(f"toy_data/{i}.dat")
+        np.save(f"toy_data/{i}_npy.npy", data)
+
+
+@pytest.fixture
 def toy_config(gen_toy):
     config = ConfigLoader(f"{this_dir}/config_toy.yml")
+    config.set_params(f"{this_dir}/exp_params.json")
+    return config
+
+
+@pytest.fixture
+def toy_config_npy(toy_npy):
+    config = ConfigLoader(f"{this_dir}/config_toy_npy.yml")
     config.set_params(f"{this_dir}/exp_params.json")
     return config
 
@@ -368,3 +382,8 @@ def test_plot_2dpull(toy_config):
     a, b = toy_config.get_dalitz_boundary("R_BC", "R_CD")
     plt.plot(a, b, color="red")
     plt.savefig("adptive_2d.png")
+
+
+def test_lazy_file(toy_config_npy):
+    fcn = toy_config_npy.get_fcn()
+    fcn.nll_grad()

--- a/tutorials/examples/create_lazy_cached_data.py
+++ b/tutorials/examples/create_lazy_cached_data.py
@@ -1,0 +1,25 @@
+from tf_pwa.config_loader import ConfigLoader
+
+# import extra_amp
+
+batch_size = 100000
+config = ConfigLoader("config.yml")
+
+
+def create_cached_file(d):
+    d.prefetch = 0
+    d.batch(batch_size)
+    for i in d:
+        # iter for Dataset
+        pass
+
+
+data, phsp, bg, *_ = config.get_all_data()
+
+for i in range(len(data)):
+    if bg is None or bg[i] is None:
+        data_bg_merged = data[i]
+    else:
+        data_bg_merged = data[i].merge(bg[i])
+    create_cached_file(data_bg_merged)
+    create_cached_file(phsp[i])


### PR DESCRIPTION
[memmap](https://numpy.org/doc/stable/reference/generated/numpy.load.html) for npy file, it can reduce memory useage.
And option for [Dataset.prefetch](https://tensorflow.google.cn/api_docs/python/tf/data/Dataset#prefetch).
mv cp_trans to preprocessor
```
data:
    phsp: [phsp.npy] # only support npy file
    lazy_call: True 
    lazy_file: True # bool
    lazy_prefetch: 2  # int , -1 for auto, 0 for no, >0 for exact value
```