### PR TITLE
systematic uncertainties from fix parameters.

### DIFF
--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -960,23 +960,23 @@ class ConfigLoader(BaseConfig):
 
     def attach_fix_params_error(self, params: dict, V_b=None) -> np.ndarray:
         """
-        In the fit results
+        The minimal condition
 
         .. math::
             -\\frac{\\partial\\ln L(a,b)}{\\partial a} = 0,
 
-        We can threat it as a implect function of :math:`a(b)`. the gradients
+        can be treated as a implect function :math:`a(b)`. The gradients is
 
         .. math::
             \\frac{\\partial a }{\\partial b} = - (\\frac{\\partial^2 \ln L(a,b)}{\\partial a \\partial a })^{-1}
-            \\frac{\\partial \ln L(a,b)}{\\partial a\\partial b }
+            \\frac{\\partial \ln L(a,b)}{\\partial a\\partial b }.
 
-        The uncertanties from b with error matrix :math:`V_b` for a is
+        The uncertanties from b with error matrix :math:`V_b` can propagate to a as
 
         .. math::
             V_a = \\frac{\\partial a }{\\partial b} V_b \\frac{\\partial a }{\\partial b}
 
-        This result will be added to the config.inv_he
+        This matrix will be added to the config.inv_he.
 
         """
         fcn = self.get_fcn()
@@ -986,14 +986,15 @@ class ConfigLoader(BaseConfig):
         all_params = list(fcn.vm.trainable_vars)
         old_params = [i for i in all_params if i not in new_params]
         _, _, hess = fcn.nll_grad_hessian()
+        hess = data_to_numpy(hess)
         for i in new_params:
             fcn.vm.set_fix(i)
 
         idx_a = np.array([all_params.index(i) for i in old_params])
         idx_b = np.array([all_params.index(i) for i in new_params])
 
-        hess_aa = hess[idx_a, idx_a]
-        hess_ab = hess[idx_a, idx_b]
+        hess_aa = hess[idx_a][:, idx_a]
+        hess_ab = hess[idx_a][:, idx_b]
 
         hess_aa = np.stack(hess_aa)
         hess_ab = np.stack(hess_ab)

--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -958,6 +958,60 @@ class ConfigLoader(BaseConfig):
         with self.vm.mask_params(params):
             yield
 
+    def attach_fix_params_error(self, params: dict, V_b=None) -> np.ndarray:
+        """
+        In the fit results
+
+        .. math::
+            -\\frac{\\partial\\ln L(a,b)}{\\partial a} = 0,
+
+        We can threat it as a implect function of :math:`a(b)`. the gradients
+
+        .. math::
+            \\frac{\\partial a }{\\partial b} = - (\\frac{\\partial^2 \ln L(a,b)}{\\partial a \\partial a })^{-1}
+            \\frac{\\partial \ln L(a,b)}{\\partial a\\partial b }
+
+        The uncertanties from b with error matrix :math:`V_b` for a is
+
+        .. math::
+            V_a = \\frac{\\partial a }{\\partial b} V_b \\frac{\\partial a }{\\partial b}
+
+        This result will be added to the config.inv_he
+
+        """
+        fcn = self.get_fcn()
+        new_params = list(params)
+        for i in new_params:
+            fcn.vm.set_fix(i, unfix=True)
+        all_params = list(fcn.vm.trainable_vars)
+        old_params = [i for i in all_params if i not in new_params]
+        _, _, hess = fcn.nll_grad_hessian()
+        for i in new_params:
+            fcn.vm.set_fix(i)
+
+        idx_a = np.array([all_params.index(i) for i in old_params])
+        idx_b = np.array([all_params.index(i) for i in new_params])
+
+        hess_aa = hess[idx_a, idx_a]
+        hess_ab = hess[idx_a, idx_b]
+
+        hess_aa = np.stack(hess_aa)
+        hess_ab = np.stack(hess_ab)
+        grad = np.dot(np.linalg.inv(hess_aa), hess_ab)
+
+        if V_b is None:
+            V_b = np.diag(list(params.values())) ** 2
+
+        V = np.dot(np.dot(grad, V_b), grad.T)
+
+        if self.inv_he is None:
+            old_V = 0.0
+        else:
+            old_V = self.inv_he
+        new_V = old_V + V
+        self.inv_he = new_V
+        return self.inv_he
+
     def batch_sum_var(self, *args, **kwargs):
         return self.vm.batch_sum_var(*args, **kwargs)
 

--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -1010,7 +1010,7 @@ class ConfigLoader(BaseConfig):
             old_V = self.inv_he
         new_V = old_V + V
         self.inv_he = new_V
-        return self.inv_he
+        return V
 
     def batch_sum_var(self, *args, **kwargs):
         return self.vm.batch_sum_var(*args, **kwargs)

--- a/tf_pwa/tests/test_amp.py
+++ b/tf_pwa/tests/test_amp.py
@@ -194,8 +194,10 @@ def test_linear_npy():
     )
 
 
-def simple_run(name):
-    a = get_particle(name, J=1, P=-1, model=name, mass=3.6, width=0.01)
+def simple_run(name, **kwargs):
+    a = get_particle(
+        name, J=1, P=-1, model=name, mass=3.6, width=0.01, **kwargs
+    )
     b = [get_particle(i, J=0, P=-1) for i in "ac"]
     get_decay(a, b)
     a.init_params()
@@ -254,6 +256,7 @@ def test_one():
     simple_run("exp")
     simple_run("exp_com")
     simple_run("BWR_normal")
+    simple_run("BWR", width_norm=True)
 
 
 def test_model2():
@@ -265,6 +268,7 @@ def test_model2():
 
 def test_model3():
     simple_run3("gls-bf", below_threshold=True)
+    simple_run3("gls-bf", force_min_l=True)
 
 
 def test_model_new():

--- a/tf_pwa/tests/test_full.py
+++ b/tf_pwa/tests/test_full.py
@@ -320,6 +320,8 @@ def test_fit(toy_config, fit_result):
         frac = [i / int_mc() for i in y]
     pt.get_error(frac)
 
+    toy_config.attach_fix_params_error({"R_BC_mass": 0.01})
+
 
 def test_bacth_sum(toy_config, fit_result):
     toy_config.get_params_error(fit_result)


### PR DESCRIPTION
Propagate uncertainties from fix params to fit params using AD.
The minimal condition

$$- \frac{\partial \ln L(a,b)}{\partial a} = 0$$

is a implicit function $a(b)$. The jacobian is

$$\frac{\partial a}{\partial b} = - （\frac{\partial^2 \ln L}{\partial a \partial a})^{-1} \frac{\partial^2 \ln L}{\partial a \partial b}.$$

The uncertainties from fix paramters $b$, can be propagete to $a$ as

$$V_a = \frac{\partial a}{\partial b} V_b \frac{\partial a}{\partial b}.$$

```
V = config.attach_fix_params_error({"A_mass": 0.01})
```
Then V
will be added to `config.inv_he`.
The `config.params_trans()` will include the uncertainties of fix parameters. 
To solve the systematic uncertainties only, set `config.inv_he=None` first.

