### PR TITLE
feat: pre_trans for variable

### DIFF
--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -335,18 +335,18 @@ class ConfigLoader(BaseConfig):
         for k, v in dic.items():
             x = v.pop("x", None)
             if x is not None:
-                if isinstance(x, list):
-                    var_equal.append([k, x[0]])
-                elif isinstance(x, str):
-                    var_equal.append([k, x])
+                if isinstance(x, list) and k != x[0]:
+                    var_equal.append([x[0], k])
+                elif isinstance(x, str) and x != k:
+                    var_equal.append([x, k])
                 else:
                     raise TypeError("x should be str or list")
             else:
                 x = k
             v["x"] = x
             pre_trans[k] = v
-        self.add_pre_trans_constraints(amp, pre_trans)
-        self.add_var_equal_constraints(amp, var_equal)
+        ConfigLoader.add_pre_trans_constraints(self, amp, pre_trans)
+        ConfigLoader.add_var_equal_constraints(self, amp, var_equal)
 
     def add_decay_constraints(self, amp, dic=None):
         if dic is None:

--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -264,6 +264,7 @@ class ConfigLoader(BaseConfig):
         self.add_free_var_constraints(amp, constrains.get("free_var", []))
         self.add_var_range_constraints(amp, constrains.get("var_range", {}))
         self.add_var_equal_constraints(amp, constrains.get("var_equal", []))
+        self.add_pre_trans_constraints(amp, constrains.get("pre_trans", None))
         self.add_gauss_constr_constraints(
             amp, constrains.get("gauss_constr", {})
         )
@@ -311,6 +312,16 @@ class ConfigLoader(BaseConfig):
         for k in dic:
             print("same value:", k)
             amp.vm.set_same(k)
+
+    def add_pre_trans_constraints(self, amp, dic=None):
+        if dic is None:
+            return
+        from tf_pwa.transform import create_trans
+
+        for k, v in dic.items():
+            print("transform:", k, v)
+            trans = create_trans(v)
+            amp.vm.pre_trans[k] = trans
 
     def add_decay_constraints(self, amp, dic=None):
         if dic is None:

--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -332,12 +332,15 @@ class ConfigLoader(BaseConfig):
             return
         var_equal = []
         pre_trans = {}
+        new_var = []
         for k, v in dic.items():
             x = v.pop("x", None)
             if x is not None:
                 if isinstance(x, list) and k != x[0]:
+                    new_var += x
                     var_equal.append([x[0], k])
                 elif isinstance(x, str) and x != k:
+                    new_var.append(x)
                     var_equal.append([x, k])
                 else:
                     raise TypeError("x should be str or list")
@@ -345,8 +348,11 @@ class ConfigLoader(BaseConfig):
                 x = k
             v["x"] = x
             pre_trans[k] = v
-        ConfigLoader.add_pre_trans_constraints(self, amp, pre_trans)
+        for i in new_var:
+            if i not in amp.vm.variables:
+                amp.vm.add_real_var(i)
         ConfigLoader.add_var_equal_constraints(self, amp, var_equal)
+        ConfigLoader.add_pre_trans_constraints(self, amp, pre_trans)
 
     def add_decay_constraints(self, amp, dic=None):
         if dic is None:

--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -323,6 +323,7 @@ class ConfigLoader(BaseConfig):
 
         for k, v in dic.items():
             print("transform:", k, v)
+            v["x"] = v.get("x", k)
             trans = create_trans(v)
             amp.vm.pre_trans[k] = trans
 
@@ -334,7 +335,15 @@ class ConfigLoader(BaseConfig):
         for k, v in dic.items():
             x = v.pop("x", None)
             if x is not None:
-                var_equal.append([k, x])
+                if isinstance(x, list):
+                    var_equal.append([k, x[0]])
+                elif isinstance(x, str):
+                    var_equal.append([k, x])
+                else:
+                    raise TypeError("x should be str or list")
+            else:
+                x = k
+            v["x"] = x
             pre_trans[k] = v
         self.add_pre_trans_constraints(amp, pre_trans)
         self.add_var_equal_constraints(amp, var_equal)

--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -265,6 +265,9 @@ class ConfigLoader(BaseConfig):
         self.add_var_range_constraints(amp, constrains.get("var_range", {}))
         self.add_var_equal_constraints(amp, constrains.get("var_equal", []))
         self.add_pre_trans_constraints(amp, constrains.get("pre_trans", None))
+        self.add_from_trans_constraints(
+            amp, constrains.get("from_trans", None)
+        )
         self.add_gauss_constr_constraints(
             amp, constrains.get("gauss_constr", {})
         )
@@ -322,6 +325,19 @@ class ConfigLoader(BaseConfig):
             print("transform:", k, v)
             trans = create_trans(v)
             amp.vm.pre_trans[k] = trans
+
+    def add_from_trans_constraints(self, amp, dic=None):
+        if dic is None:
+            return
+        var_equal = []
+        pre_trans = {}
+        for k, v in dic.items():
+            x = v.pop("x", None)
+            if x is not None:
+                var_equal.append([k, x])
+            pre_trans[k] = v
+        self.add_pre_trans_constraints(amp, pre_trans)
+        self.add_var_equal_constraints(amp, var_equal)
 
     def add_decay_constraints(self, amp, dic=None):
         if dic is None:

--- a/tf_pwa/tests/config_toy2.yml
+++ b/tf_pwa/tests/config_toy2.yml
@@ -34,6 +34,11 @@ particle:
 constrains:
   particle: null
   decay: null
+  pre_trans:
+    "R_BC_mass":
+      model: linear
+      k: 1.0
+      b: 0.0
 
 plot:
   config:

--- a/tf_pwa/tests/config_toy2.yml
+++ b/tf_pwa/tests/config_toy2.yml
@@ -34,11 +34,12 @@ particle:
 constrains:
   particle: null
   decay: null
-  pre_trans:
-    "R_BC_mass":
+  from_trans:
+    "R_BD_mass":
+      x: R_CD_mass
       model: linear
       k: 1.0
-      b: 0.0
+      b: 0.01
 
 plot:
   config:

--- a/tf_pwa/tests/test_variable.py
+++ b/tf_pwa/tests/test_variable.py
@@ -142,3 +142,30 @@ def test_rename():
         vm.rename_var("d", "c", True)
         assert vm.get("cr") == 2
         assert vm.get("ci") == 3
+
+
+def test_transform():
+    from tf_pwa.config_loader import ConfigLoader
+    from tf_pwa.transform import BaseTransform, register_trans
+
+    @register_trans("__test1")
+    class Atrans(BaseTransform):
+        def call(self, x):
+            return x[0] + x[1]
+
+    class Tmp:
+        pass
+
+    tmp = Tmp()
+    with variable_scope() as vm:
+        tmp.vm = vm
+        Variable("a", value=1.0)
+        Variable("b", value=1.0)
+        Variable("c", value=1.0)
+        ConfigLoader.add_from_trans_constraints(
+            None, tmp, {"a": {"x": ["c", "b"], "model": "__test1"}}
+        )
+    assert np.allclose(vm.get("a"), 2.0)
+    vm.set("a", 1.0)
+    assert vm.get_all_dic(False) == {"a": 2.0, "b": 1.0, "c": 1.0}
+    print(vm.get_all_dic(True))

--- a/tf_pwa/tests/test_variable.py
+++ b/tf_pwa/tests/test_variable.py
@@ -161,10 +161,10 @@ def test_transform():
         tmp.vm = vm
         Variable("a", value=1.0)
         Variable("b", value=1.0)
-        Variable("c", value=1.0)
         ConfigLoader.add_from_trans_constraints(
             None, tmp, {"a": {"x": ["c", "b"], "model": "__test1"}}
         )
+    vm.set("c", 1.0)
     assert np.allclose(vm.get("a"), 2.0)
     vm.set("a", 1.0)
     assert vm.get_all_dic(False) == {"a": 2.0, "b": 1.0, "c": 1.0}

--- a/tf_pwa/transform.py
+++ b/tf_pwa/transform.py
@@ -37,7 +37,7 @@ def create_trans(item: dict) -> BaseTransform:
 @register_trans("linear")
 class LinearTrans(BaseTransform):
     def __init__(
-        self, x: (list | str), k: float = 1.0, b: float = 0.0, **kwargs
+        self, x: "list | str", k: float = 1.0, b: float = 0.0, **kwargs
     ):
         self.x = x
         self.k = k

--- a/tf_pwa/transform.py
+++ b/tf_pwa/transform.py
@@ -6,14 +6,23 @@ T = "Tensor"
 
 
 class BaseTransform:
-    def __call__(self, x: T) -> T:
+    def __call__(self, dic: dict) -> T:
+        x = self.read(dic)
         return self.call(x)
+
+    def read(self, x: dict) -> T:
+        if isinstance(self.x, (list, tuple)):
+            return [x[i] for i in self.x]
+        elif isinstance(self.x, str):
+            return x[self.x]
+        else:
+            raise TypeError("only str of list of str is supported for x")
 
     def call(self, x: T) -> T:
         raise NotImplementedError()
 
     def inverse(self, y: T) -> T:
-        raise NotImplementedError()
+        return None
 
 
 def create_trans(item: dict) -> BaseTransform:
@@ -27,11 +36,14 @@ def create_trans(item: dict) -> BaseTransform:
 @register_trans("default")
 @register_trans("linear")
 class LinearTrans(BaseTransform):
-    def __init__(self, k: float = 1.0, b: float = 0.0, **kwargs):
+    def __init__(
+        self, x: (list | str), k: float = 1.0, b: float = 0.0, **kwargs
+    ):
+        self.x = x
         self.k = k
         self.b = b
 
-    def call(self, x: T) -> T:
+    def call(self, x) -> T:
         return self.k * x + self.b
 
     def inverse(self, x: T) -> T:

--- a/tf_pwa/transform.py
+++ b/tf_pwa/transform.py
@@ -6,6 +6,9 @@ T = "Tensor"
 
 
 class BaseTransform:
+    def __init__(self, x: "list | str", **kwargs):
+        self.x = x
+
     def __call__(self, dic: dict) -> T:
         x = self.read(dic)
         return self.call(x)
@@ -39,7 +42,7 @@ class LinearTrans(BaseTransform):
     def __init__(
         self, x: "list | str", k: float = 1.0, b: float = 0.0, **kwargs
     ):
-        self.x = x
+        super().__init__(x)
         self.k = k
         self.b = b
 

--- a/tf_pwa/transform.py
+++ b/tf_pwa/transform.py
@@ -17,20 +17,19 @@ class BaseTransform:
 
 
 def create_trans(item: dict) -> BaseTransform:
-    cls = get_trans(item.get("model", "default"))
+    model = item.pop("model", "default")
+    cls = get_trans(model)
     obj = cls(**item)
+    obj._model_name = model
     return obj
 
 
 @register_trans("default")
 @register_trans("linear")
 class LinearTrans(BaseTransform):
-    def __init__(
-        self, k: float = 1.0, b: float = 0.0, model: str = "", **kwargs
-    ):
+    def __init__(self, k: float = 1.0, b: float = 0.0, **kwargs):
         self.k = k
         self.b = b
-        self.model = model
 
     def call(self, x: T) -> T:
         return self.k * x + self.b

--- a/tf_pwa/transform.py
+++ b/tf_pwa/transform.py
@@ -1,0 +1,39 @@
+from .config import create_config
+
+set_trans, get_trans, register_trans = create_config()
+
+T = "Tensor"
+
+
+class BaseTransform:
+    def __call__(self, x: T) -> T:
+        return self.call(x)
+
+    def call(self, x: T) -> T:
+        raise NotImplementedError()
+
+    def inverse(self, y: T) -> T:
+        raise NotImplementedError()
+
+
+def create_trans(item: dict) -> BaseTransform:
+    cls = get_trans(item.get("model", "default"))
+    obj = cls(**item)
+    return obj
+
+
+@register_trans("default")
+@register_trans("linear")
+class LinearTrans(BaseTransform):
+    def __init__(
+        self, k: float = 1.0, b: float = 0.0, model: str = "", **kwargs
+    ):
+        self.k = k
+        self.b = b
+        self.model = model
+
+    def call(self, x: T) -> T:
+        return self.k * x + self.b
+
+    def inverse(self, x: T) -> T:
+        return (x - self.b) / self.k

--- a/tf_pwa/variable.py
+++ b/tf_pwa/variable.py
@@ -511,8 +511,8 @@ class VarsManager(object):
                     self.trainable_vars.remove(name)
                 else:
                     # if one is untrainable, the others will all be untrainable
-                    var = self.variables.get(name, None)
-                    if var is not None:
+                    var2 = self.variables.get(name, None)
+                    if var2 is not None:
                         if name_list[0] in self.trainable_vars:
                             self.trainable_vars.remove(name_list[0])
             for name in name_list:

--- a/tf_pwa/variable.py
+++ b/tf_pwa/variable.py
@@ -537,7 +537,7 @@ class VarsManager(object):
         if not val_in_fit or name not in self.bnd_dic:
             value = self.variables[name]
             if name in self.pre_trans:
-                value = self.pre_trans[name](value)
+                value = self.pre_trans[name](self.variables)
             return value.numpy()  # tf.Variable
         else:
             return self.bnd_dic[name].get_y2x(self.variables[name].numpy())
@@ -548,7 +548,7 @@ class VarsManager(object):
             val = tf.stop_gradient(tf.cast(self.mask_vars[name], val.dtype))
         if name in self.pre_trans:
             trans = self.pre_trans[name]
-            val = trans(val)
+            val = trans(self.variables)
         return val
 
     def set(self, name, value, val_in_fit=True):
@@ -564,7 +564,8 @@ class VarsManager(object):
             if name in self.pre_trans:
                 trans = self.pre_trans[name]
                 value = trans.inverse(value)
-            self.variables[name].assign(value)
+            if value is not None:
+                self.variables[name].assign(value)
         else:
             warnings.warn("{} not found".format(name))
 

--- a/tf_pwa/variable.py
+++ b/tf_pwa/variable.py
@@ -643,13 +643,13 @@ class VarsManager(object):
         dic = {}
         if trainable_only:
             for i in self.trainable_vars:
-                val = self.variables[i].numpy()
+                val = self.read(i).numpy()
                 # if i in self.bnd_dic:
                 #     val = self.bnd_dic[i].get_y2x(val)
                 dic[i] = val
         else:
             for i in self.variables:
-                val = self.variables[i].numpy()
+                val = self.read(i).numpy()
                 # if i in self.bnd_dic:
                 #    val = self.bnd_dic[i].get_y2x(val)
                 dic[i] = val


### PR DESCRIPTION
Add transform before read variables. We can set two variable to the same, and add transform for one variable to make the constrains of linear transform.  For example,
```
constrains:
    var_equal: [[var_name, var_name2]]
    pre_trans:
         var_name2:
              model: linear
              k: 2.0
              b: 0.0
```
then `var_name2` will be `2 * var_name`.
