### PR TITLE
Fractions constrains

### DIFF
--- a/tf_pwa/amp/amp.py
+++ b/tf_pwa/amp/amp.py
@@ -142,6 +142,11 @@ class BaseAmplitudeModel(AbsPDF):
     def set_used_res(self, res):
         self.decay_group.set_used_res(res)
 
+    @contextlib.contextmanager
+    def temp_used_res(self, res):
+        with self.decay_group.temp_used_res(res):
+            yield
+
     def set_used_chains(self, used_chains):
         self.decay_group.set_used_chains(used_chains)
 

--- a/tf_pwa/amp/core.py
+++ b/tf_pwa/amp/core.py
@@ -1921,6 +1921,13 @@ class DecayGroup(BaseDecayGroup, AmpBase):
             self.set_used_chains(used_decay)
         self.add_used_chains(idx_chains)
 
+    @contextlib.contextmanager
+    def temp_used_res(self, res):
+        old_idx = self.chains_idx
+        self.set_used_res(res)
+        yield
+        self.chains_idx = old_idx
+
     def add_used_chains(self, used_chains):
         for i in used_chains:
             assert isinstance(i, int), "not index of chains"

--- a/tf_pwa/model/custom.py
+++ b/tf_pwa/model/custom.py
@@ -192,6 +192,25 @@ class SimpleNllModel(BaseCustomModel):
         return nll + nll_norm
 
 
+@register_nll_model("simple_cfit")
+class SimpleNllModel(BaseCustomModel):
+    def eval_normal_factors(self, mcdata, weight):
+        amp = self.Amp(mcdata) * weight * mcdata.get("eff_value", 1.0)
+        a = tf.reduce_sum(amp)
+
+        bg = weight * mcdata.get("bg_value", 1.0)
+        b = tf.reduce_sum(bg)
+        return [a, b]
+
+    def eval_nll_part(self, data, weight, norm, idx=0):
+        bg_frac = self.w_bkg
+        pdf = (1 - bg_frac) * self.Amp(data) / norm[0] + bg_frac * data.get(
+            "bg_value", 1.0
+        ) / norm[1]
+        nll = -tf.reduce_sum(weight * tf.math.log(pdf))
+        return nll
+
+
 @register_nll_model("simple_chi2")
 class SimpleChi2Model(BaseCustomModel):
     """

--- a/tf_pwa/model/custom.py
+++ b/tf_pwa/model/custom.py
@@ -193,7 +193,9 @@ class SimpleNllModel(BaseCustomModel):
 
 
 @register_nll_model("simple_cfit")
-class SimpleNllModel(BaseCustomModel):
+class SimpleCFitModel(BaseCustomModel):
+    required_params = ["bg_frac"]
+
     def eval_normal_factors(self, mcdata, weight):
         amp = self.Amp(mcdata) * weight * mcdata.get("eff_value", 1.0)
         a = tf.reduce_sum(amp)
@@ -203,7 +205,7 @@ class SimpleNllModel(BaseCustomModel):
         return [a, b]
 
     def eval_nll_part(self, data, weight, norm, idx=0):
-        bg_frac = self.w_bkg
+        bg_frac = self.bg_frac
         pdf = (1 - bg_frac) * self.Amp(data) / norm[0] + bg_frac * data.get(
             "bg_value", 1.0
         ) / norm[1]

--- a/tf_pwa/model/model.py
+++ b/tf_pwa/model/model.py
@@ -583,7 +583,11 @@ class Model(object):
     :param w_bkg: Real number. The weight of background.
     """
 
-    def __init__(self, amp, w_bkg=1.0, resolution_size=1, extended=False):
+    def __init__(
+        self, amp, w_bkg=1.0, resolution_size=1, extended=False, **kwargs
+    ):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
         self.model = BaseModel(
             amp, resolution_size=resolution_size, extended=extended
         )

--- a/tf_pwa/tests/test_custum_nll.py
+++ b/tf_pwa/tests/test_custum_nll.py
@@ -53,3 +53,15 @@ def test_constr_frac_model(gen_toy, toy_config):
     print(fcn())
     print(fcn.nll_grad())
     print(fcn.nll_grad_hessian(batch=600))
+
+
+def test_cift_constr_frac_model(gen_toy, toy_config):
+    with open(f"{this_dir}/config_cfit.yml") as f:
+        dic = yaml.full_load(f)
+    dic["data"]["model"] = "cfit_constr_frac"
+    dic["nll_model"] = {"constr_frac": {"R_BC": {"value": 0.1, "sigma": 0.01}}}
+    config = ConfigLoader(dic)
+    fcn = config.get_fcn(batch=600)
+    print(fcn())
+    print(fcn.nll_grad())
+    print(fcn.nll_grad_hessian(batch=600))

--- a/tf_pwa/tests/test_custum_nll.py
+++ b/tf_pwa/tests/test_custum_nll.py
@@ -30,3 +30,15 @@ def test_simplechi2_model(gen_toy, toy_config):
     print(fcn())
     print(fcn.nll_grad())
     print(fcn.nll_grad_hessian(batch=600))
+
+
+def test_simplecfit_model(gen_toy, toy_config):
+    with open(f"{this_dir}/config_cfit.yml") as f:
+        dic = yaml.full_load(f)
+    dic["data"]["model"] = "simple_cfit"
+    dic["data"]["bg_weight"] = dic["data"]["bg_frac"]
+    config = ConfigLoader(dic)
+    fcn = config.get_fcn(batch=600)
+    print(fcn())
+    print(fcn.nll_grad())
+    print(fcn.nll_grad_hessian(batch=600))

--- a/tf_pwa/tests/test_custum_nll.py
+++ b/tf_pwa/tests/test_custum_nll.py
@@ -41,3 +41,15 @@ def test_simplecfit_model(gen_toy, toy_config):
     print(fcn())
     print(fcn.nll_grad())
     print(fcn.nll_grad_hessian(batch=600))
+
+
+def test_constr_frac_model(gen_toy, toy_config):
+    with open(f"{this_dir}/config_toy.yml") as f:
+        dic = yaml.full_load(f)
+    dic["data"]["model"] = "constr_frac"
+    dic["nll_model"] = {"constr_frac": {"R_BC": {"value": 0.1, "sigma": 0.01}}}
+    config = ConfigLoader(dic)
+    fcn = config.get_fcn(batch=600)
+    print(fcn())
+    print(fcn.nll_grad())
+    print(fcn.nll_grad_hessian(batch=600))

--- a/tf_pwa/tests/test_custum_nll.py
+++ b/tf_pwa/tests/test_custum_nll.py
@@ -36,7 +36,6 @@ def test_simplecfit_model(gen_toy, toy_config):
     with open(f"{this_dir}/config_cfit.yml") as f:
         dic = yaml.full_load(f)
     dic["data"]["model"] = "simple_cfit"
-    dic["data"]["bg_weight"] = dic["data"]["bg_frac"]
     config = ConfigLoader(dic)
     fcn = config.get_fcn(batch=600)
     print(fcn())


### PR DESCRIPTION
New NLL model which allow constrain the fractions (with eff) of some components.
```
data:
    model: constr_frac

nll_params:
    constr_frac:
         res: 
              value: 0.2
              sigma: 0.03
```

it will add additional terms in nll
$$-\ln L \Rightarrow -\ln L  + \frac{1}{2 \sigma^2} (f(\theta) - f_{exp})^2$$

$$f(\theta) \approx \frac{\int |A_i|^2 \color{red}\epsilon\color{black} d\Phi}{\int |A|^2 \color{red}\epsilon \color{black}d\Phi} $$

