### PR TITLE
More options for solve_pole

### DIFF
--- a/tf_pwa/amp/base.py
+++ b/tf_pwa/amp/base.py
@@ -142,7 +142,7 @@ class ParticleBWRCoupling(Particle):
         ret = tf.complex(a_r / a_d, a_i / a_d)
         return ret
 
-    def get_sympy_dom(self, m, m0, g0, m1=None, m2=None):
+    def get_sympy_dom(self, m, m0, g0, m1=None, m2=None, sheet=0):
         from tf_pwa.formula import BWR_coupling_dom
 
         if self.bw_l is None:

--- a/tf_pwa/amp/core.py
+++ b/tf_pwa/amp/core.py
@@ -663,6 +663,8 @@ class HelicityDecay(AmpDecay):
 
     (5). `l_list=[l1, l2]` and `ls_list=[[l1, s1], [l2, s2]]` options give the list of all possible LS used in the decay.
 
+    (6). `no_q0=True` will set the :math:`q_0=1`.
+
     """
 
     def __init__(

--- a/tf_pwa/amp/flatte.py
+++ b/tf_pwa/amp/flatte.py
@@ -228,11 +228,9 @@ The plot use parameters :math:`m_0=0.7, m_{0,1}=m_{0,2}=0.1, m_{1,1}=m_{1,2}=0.3
         >>> _ = plot_particle_model("FlatteGen", {"mass_list": [[0.1, 0.1], [0.3,0.3]], "l_list": [0, 1], "mass": 0.7}, {"R_BC_g_0": 0.3,"R_BC_g_1": 0.2})
         >>> _ = plt.legend(["all l=0", "has_bprime=False", "cut_phsp=True", "normal"])
 
-
   `no_m0=True` to set :math:`i m_0 => i` in the width part.
 
-  `no_q0=True` to remove :math:`\\frac{m_0}{|q_{i0}|}=0` and set others :math:`q_{i0}=1`.
-
+  `no_q0=True` to remove :math:`\\frac{m_0}{|q_{i0}|}` and set others :math:`q_{i0}=1`.
 
     .. plot::
 

--- a/tf_pwa/amp/flatte.py
+++ b/tf_pwa/amp/flatte.py
@@ -131,7 +131,7 @@ Required input arguments `mass_list: [[m11, m12], [m21, m22]]` for :math:`m_{i,1
         import sympy as sym
 
         gi = [sym.var(f"g_{i}") for i, _ in enumerate(self.mass_list)]
-        return *sym.var("m m0"), *gi
+        return (*sym.var("m m0"), *gi)
 
     def get_num_var(self):
         mass = self.get_mass()

--- a/tf_pwa/amp/flatte.py
+++ b/tf_pwa/amp/flatte.py
@@ -136,7 +136,7 @@ Required input arguments `mass_list: [[m11, m12], [m21, m22]]` for :math:`m_{i,1
     def get_num_var(self):
         mass = self.get_mass()
         gi = [self.g_value[i]() for i, _ in enumerate(self.mass_list)]
-        return mass, *gi
+        return (mass, *gi)
 
     def get_sympy_dom(self, m, m0, *gi, sheet=0):
         import sympy as sym

--- a/tf_pwa/amp/flatte.py
+++ b/tf_pwa/amp/flatte.py
@@ -272,7 +272,7 @@ The plot use parameters :math:`m_0=0.7, m_{0,1}=m_{0,2}=0.1, m_{1,1}=m_{1,2}=0.3
     def get_num_var(self):
         mass = self.get_mass()
         gi = self.get_coeff()
-        return mass, *gi
+        return (mass, *gi)
 
     def get_amp(self, *args, **kwargs):
         m = args[0]["m"]

--- a/tf_pwa/amp/split_ls.py
+++ b/tf_pwa/amp/split_ls.py
@@ -148,7 +148,7 @@ class ParticleBWRLS(ParticleLS):
         thetas = [i() for i in self.theta]
         return mass, width, thetas, m1, m2
 
-    def get_sympy_dom(self, m, m0, g0, thetas, m1=None, m2=None):
+    def get_sympy_dom(self, m, m0, g0, thetas, m1=None, m2=None, sheet=0):
         if self.get_width() is None:
             raise NotImplemented
         from tf_pwa.formula import BWR_LS_dom

--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -442,6 +442,7 @@ class ConfigLoader(BaseConfig):
                 simple_map = {"m": "mass", "g": "width"}
 
                 gauss_constr = particle_config.get("gauss_constr", None)
+                print(particle_config, params_dic)
                 if gauss_constr is not None:
                     assert isinstance(gauss_constr, dict)
                     for k, v in gauss_constr.items():
@@ -464,14 +465,14 @@ class ConfigLoader(BaseConfig):
                     if "float" in particle_config and particle_config["float"]:
                         if "m" in particle_config["float"]:
                             p_i.mass.freed()  # set_fix(i+'_mass',unfix=True)
-                            if "m_max" in particle_config:
-                                upper = particle_config["m_max"]
+                            if "mass_max" in params_dic:
+                                upper = params_dic["mass_max"]
                             # elif m_sigma is not None:
                             #    upper = self.config["particle"][i]["m0"] + 10 * m_sigma
                             else:
                                 upper = None
-                            if "m_min" in particle_config:
-                                lower = particle_config["m_min"]
+                            if "mass_min" in params_dic:
+                                lower = params_dic["mass_min"]
                             # elif m_sigma is not None:
                             #    lower = self.config["particle"][i]["m0"] - 10 * m_sigma
                             else:
@@ -481,14 +482,14 @@ class ConfigLoader(BaseConfig):
                             self._neglect_when_set_params.append(str(p_i.mass))
                         if "g" in particle_config["float"]:
                             p_i.width.freed()  # amp.vm.set_fix(i+'_width',unfix=True)
-                            if "g_max" in particle_config:
-                                upper = particle_config["g_max"]
+                            if "width_max" in params_dic:
+                                upper = params_dic["width_max"]
                             # elif g_sigma is not None:
                             #    upper = self.config["particle"][i]["g0"] + 10 * g_sigma
                             else:
                                 upper = None
-                            if "g_min" in particle_config:
-                                lower = particle_config["g_min"]
+                            if "width_min" in params_dic:
+                                lower = params_dic["width_min"]
                             # elif g_sigma is not None:
                             #    lower = self.config["particle"][i]["g0"] - 10 * g_sigma
                             else:

--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -442,7 +442,6 @@ class ConfigLoader(BaseConfig):
                 simple_map = {"m": "mass", "g": "width"}
 
                 gauss_constr = particle_config.get("gauss_constr", None)
-                print(particle_config, params_dic)
                 if gauss_constr is not None:
                     assert isinstance(gauss_constr, dict)
                     for k, v in gauss_constr.items():

--- a/tf_pwa/config_loader/plot.py
+++ b/tf_pwa/config_loader/plot.py
@@ -296,7 +296,7 @@ def plot_partial_wave(
         data=data,
         phsp=phsp,
         bg=bg,
-        prefix="figure/",
+        prefix=prefix,
         res=res,
         save_root=save_root,
         chains_id_method=chains_id_method,

--- a/tf_pwa/fit.py
+++ b/tf_pwa/fit.py
@@ -270,6 +270,11 @@ def fit_scipy(
         # bd = Bounds(bnds)
         fcn.vm.set_bound(bounds_dict)
 
+        if fcn.vm.bnd_dic:
+            print("##boundary: ")
+        for k, v in fcn.vm.bnd_dic.items():
+            print("  ", k, "\t", v)
+
         f_g = fcn.vm.trans_fcn_grad(fcn.nll_grad)
         f_g = Cached_FG(f_g, grad_scale=grad_scale)
         # print(f_g)

--- a/tf_pwa/tests/test_formula.py
+++ b/tf_pwa/tests/test_formula.py
@@ -83,4 +83,24 @@ def test_grad():
         b = tf.math.real(a)
         c = tf.math.imag(a)
     pm.get_grad(b, keep=True)
-    pm.get_grad(c, keep=True)
+    pm.get_grad(c)
+
+
+def test_grad2():
+    p = simple_decay("BWR")
+    p.mass.freed()
+    with p.mass.vm.error_trans(None) as pm:
+        b, c = p.solve_pole(init=3.6 - 0.005j, return_complex=False)
+    pm.get_grad(b, keep=True)
+    pm.get_grad(c)
+
+
+def test_flatte_pole():
+    p = simple_decay("FlatteC", mass_list=[[0.1, 0.1], [0.3, 0.3]])
+    p.mass.freed()
+    p.mass.vm.set("FlatteC_g_0", 0.3)
+    p.mass.vm.set("FlatteC_g_1", 0.4)
+    with p.mass.vm.error_trans(None) as pm:
+        b, c = p.solve_pole(init=3.6 - 0.05j, return_complex=False, sheet=1)
+    pm.get_grad(b, keep=True)
+    pm.get_grad(c)

--- a/tf_pwa/tests/test_formula.py
+++ b/tf_pwa/tests/test_formula.py
@@ -127,22 +127,13 @@ def test_flatte2_pole():
     flatte2_pole_temp(has_bprime=True)
 
 
-def flatte2_pole_temp(**kwargs):
+def test_flatte2_width():
     p = simple_decay(
-        "Flatte2", mass_list=[[0.1, 0.1], [0.3, 0.3]], l_list=[0, 1], **kwargs
+        "Flatte2", mass_list=[[0.1, 0.1], [0.3, 0.3]], g_0=0.3, float=["g_0"]
     )
     p.mass.freed()
     p.mass.vm.set("Flatte2_g_0", 0.3)
     p.mass.vm.set("Flatte2_g_1", 0.4)
-    with p.mass.vm.error_trans(None) as pm:
-        b, c = p.solve_pole(init=3.6 - 0.05j, return_complex=False, sheet=1)
-    ga = pm.get_grad(b, keep=True)
-    gc = pm.get_grad(c)
-
-
-def test_flatte2_width():
-    p = simple_decay(
-        "Flatte2", mass_list=[[0.1, 0.1], [0.3, 0.3]], l_list=[0, 1]
-    )
+    p.solve_pole()
     width = p.get_width()
     width = p.get_width(np.array([3.6]))

--- a/tf_pwa/tests/test_formula.py
+++ b/tf_pwa/tests/test_formula.py
@@ -90,7 +90,8 @@ def test_grad2():
     p = simple_decay("BWR")
     p.mass.freed()
     with p.mass.vm.error_trans(None) as pm:
-        b, c = p.solve_pole(init=3.6 - 0.005j, return_complex=False)
+        a = p.solve_pole()
+        b, c = tf.math.real(a), tf.math.imag(a)
     pm.get_grad(b, keep=True)
     pm.get_grad(c)
 
@@ -104,3 +105,44 @@ def test_flatte_pole():
         b, c = p.solve_pole(init=3.6 - 0.05j, return_complex=False, sheet=1)
     pm.get_grad(b, keep=True)
     pm.get_grad(c)
+
+
+def flatte2_pole_temp(**kwargs):
+    p = simple_decay(
+        "Flatte2", mass_list=[[0.1, 0.1], [0.3, 0.3]], l_list=[0, 1], **kwargs
+    )
+    p.mass.freed()
+    p.mass.vm.set("Flatte2_g_0", 0.3)
+    p.mass.vm.set("Flatte2_g_1", 0.4)
+    with p.mass.vm.error_trans(None) as pm:
+        b, c = p.solve_pole(init=3.6 - 0.05j, return_complex=False, sheet=1)
+    ga = pm.get_grad(b, keep=True)
+    gc = pm.get_grad(c)
+
+
+def test_flatte2_pole():
+    flatte2_pole_temp(cut_phsp=True)
+    flatte2_pole_temp(no_q0=True)
+    flatte2_pole_temp(no_m0=True)
+    flatte2_pole_temp(has_bprime=True)
+
+
+def flatte2_pole_temp(**kwargs):
+    p = simple_decay(
+        "Flatte2", mass_list=[[0.1, 0.1], [0.3, 0.3]], l_list=[0, 1], **kwargs
+    )
+    p.mass.freed()
+    p.mass.vm.set("Flatte2_g_0", 0.3)
+    p.mass.vm.set("Flatte2_g_1", 0.4)
+    with p.mass.vm.error_trans(None) as pm:
+        b, c = p.solve_pole(init=3.6 - 0.05j, return_complex=False, sheet=1)
+    ga = pm.get_grad(b, keep=True)
+    gc = pm.get_grad(c)
+
+
+def test_flatte2_width():
+    p = simple_decay(
+        "Flatte2", mass_list=[[0.1, 0.1], [0.3, 0.3]], l_list=[0, 1]
+    )
+    width = p.get_width()
+    width = p.get_width(np.array([3.6]))


### PR DESCRIPTION
More options for solve pole, and support for Flatte.

`return_compex=Flase` to return real value
`init` to control initial value
`sheet=0` to control the behavior of +/- sqrt (for Flatte)
```
p = config.get_decay().get_particle("R1")
with config.params_trans() as pt:
    pole = p.solve_pole(return_complex=False)
print(pole, pt.get_error(pole))
```
