### PR TITLE
Comparation of different way for identical particles

### DIFF
--- a/checks/identical_particles/README.md
+++ b/checks/identical_particles/README.md
@@ -1,0 +1,14 @@
+# Comparation of different way for identical particles
+
+The script `compare_amplitude.py` compare different way of identical particles
+in (`configs/*.yml`) based on `configs/config3.yml`.
+
+The results are shown in the table.
+
+| configs                | consistent with references |
+| ---------------------- | -------------------------- |
+| config3.yml            | as references              |
+| config3_2.yml          | No                         |
+| config3_3.yml          | Yes                        |
+| config_covten.yml      | Yes                        |
+| config3_constrains.yml | Yes                        |

--- a/checks/identical_particles/compare_amplitude.py
+++ b/checks/identical_particles/compare_amplitude.py
@@ -1,0 +1,45 @@
+import numpy as np
+import tensorflow as tf
+
+from tf_pwa.amp import cov_ten
+from tf_pwa.angle import LorentzVector as lv
+from tf_pwa.config_loader import ConfigLoader
+
+config_hel = ConfigLoader("config3.yml")
+
+for i in config_hel.get_decay():
+    for j in i:
+        print(j, j.get_ls_list())
+
+phsp = config_hel.generate_phsp_p(10000)
+
+boost_vector = (np.random.random((10000, 3)) * 2 - 1) * 0.3
+
+phsp = {k: lv.boost(v, boost_vector) for k, v in phsp.items()}
+
+
+a1 = config_hel.eval_amplitude(phsp)
+scale_a1 = tf.reduce_mean(a1)
+
+for config_file in [
+    "config3_constrains.yml",
+    "config_covten3.yml",
+    "config3_2.yml",
+    "config3_3.yml",
+]:
+    config = ConfigLoader("configs/" + config_file)
+    config.set_params(config_hel.get_params())
+    ai = config.eval_amplitude(phsp)
+    scale_ai = tf.reduce_mean(ai)
+
+    chi2 = float(tf.reduce_sum(((a1 / scale_a1) / (ai / scale_ai) - 1) ** 2))
+    status = "success" if chi2 < 1e-7 else "failed"
+    print(
+        config_file,
+        "\t",
+        status,
+        "\t",
+        chi2,
+        "  \t",
+        float(scale_ai / scale_a1),
+    )

--- a/checks/identical_particles/configs/config3.yml
+++ b/checks/identical_particles/configs/config3.yml
@@ -1,0 +1,35 @@
+data:
+  dat_order: [B, C, D]
+  # add the following to options to change the behavier of alignement
+  align_ref: center_mass
+  center_mass: True
+  identical_particles: [[C, D]]
+
+decay:
+  A: [BC, D]
+  BC: [B, C]
+
+particle:
+  $top: A
+  $finals: [B, C, D]
+  A:
+    J: 1/2
+    P: -1
+    mass: 3.0
+  B:
+    J: 1/2
+    P: -1
+    mass: 0.1
+  C:
+    J: 0
+    P: -1
+    mass: 0.1
+  D:
+    J: 0
+    P: -1
+    mass: 0.1
+  BC:
+    J: 1/2
+    P: -1
+    mass: 2.0
+    width: 0.5

--- a/checks/identical_particles/configs/config3_2.yml
+++ b/checks/identical_particles/configs/config3_2.yml
@@ -1,0 +1,34 @@
+data:
+  dat_order: [B, C, D]
+  # only center_mass is not working.
+  center_mass: True
+  identical_particles: [[C, D]]
+
+decay:
+  A: [BC, D]
+  BC: [B, C]
+
+particle:
+  $top: A
+  $finals: [B, C, D]
+  A:
+    J: 1/2
+    P: -1
+    mass: 3.0
+  B:
+    J: 1/2
+    P: -1
+    mass: 0.1
+  C:
+    J: 0
+    P: -1
+    mass: 0.1
+  D:
+    J: 0
+    P: -1
+    mass: 0.1
+  BC:
+    J: 1/2
+    P: -1
+    mass: 2.0
+    width: 0.5

--- a/checks/identical_particles/configs/config3_3.yml
+++ b/checks/identical_particles/configs/config3_3.yml
@@ -1,0 +1,37 @@
+data:
+  dat_order: [B, C, D]
+  identical_particles: [[C, D]]
+
+decay:
+  A:
+    - [BC, D]
+    # add decay to B in the first decay, which will be used as reference for alignment.
+    - [CD, B]
+  BC: [B, C]
+  CD: [C, D]
+
+particle:
+  $top: A
+  $finals: [B, C, D]
+  A:
+    J: 1/2
+    P: -1
+    mass: 3.0
+  B:
+    J: 1/2
+    P: -1
+    mass: 0.1
+  C:
+    J: 0
+    P: -1
+    mass: 0.1
+  D:
+    J: 0
+    P: -1
+    mass: 0.1
+  CD: []
+  BC:
+    J: 1/2
+    P: -1
+    mass: 2.0
+    width: 0.5

--- a/checks/identical_particles/configs/config3_constrains.yml
+++ b/checks/identical_particles/configs/config3_constrains.yml
@@ -1,0 +1,45 @@
+data:
+  dat_order: [B, C, D]
+
+decay:
+  A:
+    - [BC, D]
+    - [BD, C]
+  BC: [B, C]
+  BD: [B, D]
+
+particle:
+  $top: A
+  $finals: [B, C, D]
+  A:
+    J: 1/2
+    P: -1
+    mass: 3.0
+  B:
+    J: 1/2
+    P: -1
+    mass: 0.1
+  C:
+    J: 0
+    P: -1
+    mass: 0.1
+  D:
+    J: 0
+    P: -1
+    mass: 0.1
+  BC:
+    J: 1/2
+    P: -1
+    mass: 2.0
+    width: 0.5
+  BD:
+    J: 1/2
+    P: -1
+    mass: 2.0
+    width: 0.5
+
+constrains:
+  # constraint the same total coupling, and also for g_ls if multiply g_ls exists.
+  var_equal:
+    - [A->BC.DBC->B.C_total_0r, A->BD.CBD->B.D_total_0r]
+    - [A->BC.DBC->B.C_total_0i, A->BD.CBD->B.D_total_0i]

--- a/checks/identical_particles/configs/config_covten3.yml
+++ b/checks/identical_particles/configs/config_covten3.yml
@@ -1,0 +1,33 @@
+data:
+  dat_order: [B, C, D]
+  identical_particles: [[C, D]]
+
+decay:
+  # change the decay model to cov_ten_simple
+  A: [BC, D, model: cov_ten_simple]
+  BC: [B, C, model: cov_ten_simple]
+
+particle:
+  $top: A
+  $finals: [B, C, D]
+  A:
+    J: 1/2
+    P: -1
+    mass: 3.0
+  B:
+    J: 1/2
+    P: -1
+    mass: 0.1
+  C:
+    J: 0
+    P: -1
+    mass: 0.1
+  D:
+    J: 0
+    P: -1
+    mass: 0.1
+  BC:
+    J: 1/2
+    P: -1
+    mass: 2.0
+    width: 0.5


### PR DESCRIPTION
Some example of different way to include identical particles in checks. 

Currently, you can constraint the parameters manually.

Or, the following options might works well 
```
data:
    align_ref: center_mass
    center_mass: True
    identical_particles: [[A, B]]
```
Be careful, if there are final particles whose $J\neq 0$.