### PR TITLE
dtype aligns in nll

### DIFF
--- a/tf_pwa/model/model.py
+++ b/tf_pwa/model/model.py
@@ -327,7 +327,7 @@ class BaseModel(object):
         amp_s2 = self.signal(data) * weight
         amp_s2 = self.sum_resolution(amp_s2)
         weight = tf.reduce_sum(rw, axis=-1)
-        dom_weight = tf.where(weight == 0, 1.0, weight)
+        dom_weight = tf.where(weight == 0, tf.ones_like(weight), weight)
         ln_data = clip_log(amp_s2 / dom_weight)
         mc_weight = mcdata.get("weight", tf.ones((data_shape(mcdata),)))
         int_mc = tf.reduce_sum(

--- a/tf_pwa/model/model.py
+++ b/tf_pwa/model/model.py
@@ -327,7 +327,7 @@ class BaseModel(object):
         amp_s2 = self.signal(data) * weight
         amp_s2 = self.sum_resolution(amp_s2)
         weight = tf.reduce_sum(rw, axis=-1)
-        dom_weight = tf.where(weight == 0, tf.ones_like(weight), weight)
+        dom_weight = tf.where(weight == 0, tf.constant(1.0, dtype=weight.dtype), weight)
         ln_data = clip_log(amp_s2 / dom_weight)
         mc_weight = mcdata.get("weight", tf.ones((data_shape(mcdata),)))
         int_mc = tf.reduce_sum(

--- a/tf_pwa/model/model.py
+++ b/tf_pwa/model/model.py
@@ -327,7 +327,9 @@ class BaseModel(object):
         amp_s2 = self.signal(data) * weight
         amp_s2 = self.sum_resolution(amp_s2)
         weight = tf.reduce_sum(rw, axis=-1)
-        dom_weight = tf.where(weight == 0, tf.constant(1.0, dtype=weight.dtype), weight)
+        dom_weight = tf.where(
+            weight == 0, tf.constant(1.0, dtype=weight.dtype), weight
+        )
         ln_data = clip_log(amp_s2 / dom_weight)
         mc_weight = mcdata.get("weight", tf.ones((data_shape(mcdata),)))
         int_mc = tf.reduce_sum(


### PR DESCRIPTION
Hi, small fix: the dtype of the `1.0` is float32, which fails if the function is jitted. This just ensures that the 1 has the same dtype as the weigths.

