### PR TITLE
MixConfig: fit data with the mixing of config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__
 .ipynb_checkpoints
 *.pyc
+*.diff
 
 tf_pwa/version.py
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.1" %}
+{% set version = "0.2.2" %}
 
 package:
   name: tf-pwa

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,4 @@
 *build/
 api/
 decay_model.rst
+sg_execution_times.rst

--- a/examples/ex_params_trans.py
+++ b/examples/ex_params_trans.py
@@ -69,7 +69,7 @@ import tensorflow as tf
 
 with config.params_trans() as pt:
     a2_r = pt["A->R2.CR2->B.D_total_0r"]
-    a2_i = pt["A->R2.CR2->B.D_total_0r"]
+    a2_i = pt["A->R2.CR2->B.D_total_0i"]
     a2_x = a2_r * tf.cos(a2_i)
 
 # %%
@@ -85,16 +85,14 @@ print(a2_x.numpy(), pt.get_error(a2_x).numpy())
 
 amp = config.get_amplitude()
 
-with config.params_trans() as pt1:
-    with config.params_trans() as pt:
-        int_mc = tf.reduce_sum(amp(phsp))
-        with amp.temp_used_res(["R1_a", "R1_b"]):
-            part_int_mc = tf.reduce_sum(amp(phsp))
-        ratio = part_int_mc / int_mc
-    error = pt.get_error(ratio)
+with config.params_trans() as pt:
+    int_mc = tf.reduce_sum(amp(phsp))
+    with amp.temp_used_res(["R1_a", "R1_b"]):
+        part_int_mc = tf.reduce_sum(amp(phsp))
+    ratio = part_int_mc / int_mc
+error = pt.get_error(ratio)
 
 print(ratio.numpy(), "+/-", error.numpy())
-print(error.numpy(), "+/-", pt1.get_error(error).numpy())
 
 # %%
 # For large data size it would be some problem named OOM (out of memory).

--- a/tf_pwa/config_loader/__init__.py
+++ b/tf_pwa/config_loader/__init__.py
@@ -6,6 +6,7 @@ from .config_loader import (
 )
 from .data_root_lhcb import RootData
 from .extra import *
+from .mix_config import MixConfig
 from .multi_config import MultiConfig
 from .particle_function import ParticleFunction
 from .plot import export_legend, hist_error, hist_line

--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -537,8 +537,9 @@ class ConfigLoader(BaseConfig):
                         arg_i.sameas(arg)
 
     @functools.lru_cache()
-    def _get_model(self, vm=None, name=""):
-        amp = self.get_amplitude(vm=vm, name=name)
+    def _get_model(self, vm=None, name="", amp=None):
+        if amp is None:
+            amp = self.get_amplitude(vm=vm, name=name)
         model_name = self.config["data"].get("model", "auto")
         w_bkg, w_inmc = self._get_bg_weight()
         model = []
@@ -657,7 +658,9 @@ class ConfigLoader(BaseConfig):
             w_bkg = tmp
         return w_bkg, w_inmc
 
-    def get_fcn(self, all_data=None, batch=65000, vm=None, name=""):
+    def get_fcn(
+        self, all_data=None, batch=65000, vm=None, name="", model=None
+    ):
         if all_data is None:
             if vm in self.cached_fcn:
                 return self.cached_fcn[vm]
@@ -669,7 +672,8 @@ class ConfigLoader(BaseConfig):
             inmc = [None] * self._Ngroup
         if bg is None:
             bg = [None] * self._Ngroup
-        model = self._get_model(vm=vm, name=name)
+        if model is None:
+            model = self._get_model(vm=vm, name=name)
         fcns = []
 
         # print(self.config["data"].get("using_mix_likelihood", False))

--- a/tf_pwa/config_loader/mix_config.py
+++ b/tf_pwa/config_loader/mix_config.py
@@ -1,0 +1,70 @@
+import functools
+
+from tf_pwa.amp import AmplitudeModel
+from tf_pwa.data import EvalLazy
+from tf_pwa.model import FCN
+
+from .multi_config import MultiConfig
+
+
+class MixAmplitude(AmplitudeModel):
+    def __init__(self, amps):
+        self.amps = amps
+        self.vm = amps[0].vm
+
+    def __getattr__(self, name):
+        return getattr(self.amps[-1], name)
+
+    def pdf(self, data):
+        ret = 0
+        scale = 0
+        for amp, data_i in zip(self.amps, data["datas"]):
+            w = data_i.get("weight", 1)
+            ret = ret + amp(data_i) * w
+            scale = scale + w
+        return ret / scale
+
+
+class MixConfig(MultiConfig):
+    def get_data(self, name):
+        all_data = [i.get_data(name) for i in self.configs]
+        if all_data[0] is None:
+            return all_data[0]
+        ret = []
+        for i in range(len(all_data[0])):
+            tmp = {"datas": [j[i] for j in all_data]}
+            tmp["weight"] = sum(j[i]["weight"] for j in all_data)
+            ret.append(tmp)
+        return ret
+
+    def get_all_data(self):
+        datafile = ["data", "phsp", "bg", "inmc"]
+        data, phsp, bg, inmc = [self.get_data(i) for i in datafile]
+        self._Ngroup = len(data)
+        assert len(phsp) == self._Ngroup
+        if bg is None:
+            bg = [None] * self._Ngroup
+        if inmc is None:
+            inmc = [None] * self._Ngroup
+        assert len(bg) == self._Ngroup
+        assert len(inmc) == self._Ngroup
+        return data, phsp, bg, inmc
+
+    def get_amplitude(self, vm=None, name=""):
+        amps = self.get_amplitudes(vm=vm)
+        return MixAmplitude(amps)
+
+    @functools.lru_cache()
+    def _get_model(self, vm=None, name=""):
+        amp = self.get_amplitude(vm=vm, name=name)
+        models = self.configs[0]._get_model(vm=vm, name=name, amp=amp)
+        return models
+
+    def get_fcn(self, datas=None, vm=None, batch=65000):
+        all_data = datas
+        if all_data is None:
+            all_data = self.get_all_data()
+        model = self._get_model(vm=vm)
+        return self.configs[-1].get_fcn(
+            all_data=all_data, vm=model[0].vm, batch=batch, model=model
+        )

--- a/tf_pwa/config_loader/multi_config.py
+++ b/tf_pwa/config_loader/multi_config.py
@@ -66,10 +66,17 @@ class MultiConfig(object):
         else:
             self.vm = vm
         self.total_same = total_same
-        self.configs = [
-            ConfigLoader(i, vm=self.vm, share_dict=share_dict)
-            for i in file_names
-        ]
+        self.configs = []
+        for i in file_names:
+            if isinstance(i, (str, dict)):
+                c = ConfigLoader(i, vm=self.vm, share_dict=share_dict)
+            elif isinstance(i, list):
+                from tf_pwa.config_loader import MixConfig
+
+                c = MixConfig(i, vm=self.vm, share_dict=share_dict)
+            else:
+                raise ValueError("config for {} is not supported".format(i))
+            self.configs.append(c)
         self.bound_dic = {}
         self.gauss_constr_dic = {}
         self._neglect_when_set_params = []

--- a/tf_pwa/config_loader/plot.py
+++ b/tf_pwa/config_loader/plot.py
@@ -383,6 +383,7 @@ def _get_plot_partial_wave_input(
     cut_function=lambda x: 1,
     partial_waves_function=None,
     extra_plots=None,
+    amp=None,
     **kwargs
 ):
     """
@@ -434,7 +435,8 @@ def _get_plot_partial_wave_input(
     if self.config["data"].get("model", "auto") == "cfit":
         phsp = _get_cfit_eff_phsp(self, phsp, batch)
         phsp_rec = _get_cfit_eff_phsp(self, phsp_rec, batch)
-    amp = self.get_amplitude()
+    if amp is None:
+        amp = self.get_amplitude()
     self._Ngroup = len(data)
     ws_bkg = [
         None if bg_i is None else bg_i.get("weight", None) for bg_i in bg

--- a/tf_pwa/config_loader/plot.py
+++ b/tf_pwa/config_loader/plot.py
@@ -592,6 +592,7 @@ def _cal_partial_wave(
     phsp_rec=None,
     cut_function=lambda x: 1,
     partial_waves_function=None,
+    data_index_prefix=(),
     **kwargs
 ):
     data_dict = {}
@@ -670,6 +671,11 @@ def _cal_partial_wave(
             phsp_dict["MC_{0}_{1}_fit".format(i, name_i)] = cut_phsp * sr(
                 weight_i
             )
+        if data_index_prefix:
+            data = data_index(data, data_index_prefix)
+            phsp_rec = data_index(phsp_rec, data_index_prefix)
+            if bg is not None:
+                bg = data_index(bg, data_index_prefix)
         for name in plot_var_dic:
             readdata = plot_var_dic[name]["readdata"]
             idx = plot_var_dic[name].get("idx", (None,))

--- a/tf_pwa/tests/test_full.py
+++ b/tf_pwa/tests/test_full.py
@@ -479,7 +479,7 @@ def test_mix_config_same_data(gen_toy):
         same_data=True,
     )
     config.set_params(f"{this_dir}/exp_params.json")
-    config.plot_partial_wave(prefix="toy_data/mix_plot/")
+    config.plot_partial_wave(prefix="toy_data/mix_plot/", base_idx=1)
 
 
 def test_cp_particles():

--- a/tf_pwa/tests/test_full.py
+++ b/tf_pwa/tests/test_full.py
@@ -470,6 +470,18 @@ def test_mix_config(gen_toy):
     config.plot_partial_wave(prefix="toy_data/mix_plot/")
 
 
+def test_mix_config_same_data(gen_toy):
+    from tf_pwa.config_loader import MixConfig
+
+    config = MixConfig(
+        [f"{this_dir}/config_toy.yml", f"{this_dir}/config_toy.yml"],
+        total_same=True,
+        same_data=True,
+    )
+    config.set_params(f"{this_dir}/exp_params.json")
+    config.plot_partial_wave(prefix="toy_data/mix_plot/")
+
+
 def test_cp_particles():
     config = ConfigLoader(f"{this_dir}/config_self_cp.yml")
     phsp = config.generate_phsp(100)

--- a/tf_pwa/tests/test_full.py
+++ b/tf_pwa/tests/test_full.py
@@ -459,6 +459,17 @@ def test_mix_likelihood(toy_config3):
     results = toy_config3.fit(maxiter=1)
 
 
+def test_mix_config(gen_toy):
+    from tf_pwa.config_loader import MixConfig
+
+    config = MixConfig(
+        [f"{this_dir}/config_toy.yml", f"{this_dir}/config_toy.yml"],
+        total_same=True,
+    )
+    config.set_params(f"{this_dir}/exp_params.json")
+    config.plot_partial_wave(prefix="toy_data/mix_plot/")
+
+
 def test_cp_particles():
     config = ConfigLoader(f"{this_dir}/config_self_cp.yml")
     phsp = config.generate_phsp(100)


### PR DESCRIPTION
For $x \in X$, add different variables to get data $x_i = [x, addition_i]$,
for different `config.yml` create different PDF    `P_i(x_i)`. 
The fit with the sum of PDF as 
$$P(x) = \frac{N}{\sum_j w_j} \sum_{i} w_i P_i(x_i)$$.

It can be used to fit datasets with mixing of PDFs.

```
config = MixConfig(["config1.yml", "config2.yml"], same_data=False)
config.fit()
config.plot_partial_wave(base_idx=0, prefix="figure_0/")
config.plot_partial_wave(base_idx=1, prefix="figure_1/")
```
