### PR TITLE
Simple MLP for amplitude model

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.10
       - name: Create distribution
         run: python setup.py sdist
       - name: Publish to PyPI

--- a/tf_pwa/amp/preprocess.py
+++ b/tf_pwa/amp/preprocess.py
@@ -271,3 +271,24 @@ class AddBinIndexPreProcessor(BasePreProcessor):
             idx = idx * n + n_idx
         x["bin_index"] = idx
         return x
+
+
+@register_preprocessor("add_ref_amp")
+class AddRefAmpPreProcessor(BasePreProcessor):
+    def __init__(
+        self, *args, config=None, params=None, varname="ref_amp", **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        from tf_pwa.config_loader import ConfigLoader
+
+        self.params = {} if params is None else params
+        config = ConfigLoader(config)
+        self.config = config
+        config.set_params(self.params)
+        self.ref_amp = config.get_amplitude()
+        self.varname = varname
+
+    def __call__(self, x):
+        a = self.ref_amp(x)
+        x[self.varname] = a
+        return x

--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -364,7 +364,10 @@ class ConfigLoader(BaseConfig):
 
         fix_decay = amp.decay_group.get_decay_chain(fix_total_idx)
         # fix which total factor
-        fix_decay.total.set_fix_idx(fix_idx=0, fix_vals=(fix_total_val, 0.0))
+        if hasattr(fix_decay, "total"):
+            fix_decay.total.set_fix_idx(
+                fix_idx=0, fix_vals=(fix_total_val, 0.0)
+            )
 
         decay_d = dic.get("decay_d", None)
         if decay_d is not None:
@@ -402,8 +405,9 @@ class ConfigLoader(BaseConfig):
             dic = {}
         fix_total_idx = dic.get("fix_chain_idx", 0)
         fix_decay = amp.decay_group.get_decay_chain(fix_total_idx)
-        var = fix_decay.total
-        var.vm.set_fix(var.name + "_0r", unfix=True)
+        if hasattr(fix_decay, "total"):
+            var = fix_decay.total
+            var.vm.set_fix(var.name + "_0r", unfix=True)
 
     def add_particle_constraints(self, amp, dic=None):
         if dic is None:

--- a/tf_pwa/config_loader/data.py
+++ b/tf_pwa/config_loader/data.py
@@ -226,6 +226,8 @@ class SimpleData:
                 value = value[:n_data]
             else:
                 raise NotImplemented
+            if "dtype" in v:
+                value = tf.cast(value, v["dtype"])
             extra_var[v.get("key", k)] = value
         return extra_var
 

--- a/tf_pwa/tests/config_bkg.yml
+++ b/tf_pwa/tests/config_bkg.yml
@@ -1,0 +1,46 @@
+data:
+  dat_order: [B, C, D]
+  data: ["toy_data/bg.dat"]
+  phsp: ["toy_data/PHSP.dat"]
+  extended: True
+  amp_model:
+    simple_mlp:
+      n_hidden: [5, 3]
+
+decay:
+  A:
+    - [R_BC, D]
+    - [R_BD, C]
+    - [R_CD, B]
+  R_BC: [B, C]
+  R_BD: [B, D]
+  R_CD: [C, D]
+
+particle:
+  $top:
+    A: { J: 1, P: -1, spins: [-1, 1], mass: 4.6 }
+  $finals:
+    B: { J: 1, P: -1, mass: 2.00698 }
+    C: { J: 1, P: -1, mass: 2.01028 }
+    D: { J: 0, P: -1, mass: 0.13957 }
+  R_BC: { J: 1, Par: 1, m0: 4.16, g0: 0.1, params: { mass_range: [4.0, 4.2] } }
+  R_BD: []
+  R_CD: []
+
+constrains:
+  particle: null
+  decay: null
+
+plot:
+  mass:
+    R_BC: { display: "$M_{BC}$" }
+    R_BD: { display: "$M_{BD}$" }
+    R_CD: { display: "$M_{CD}$" }
+  angle:
+    R_BC/B:
+      cos(beta):
+        display: "cos $\\theta$"
+        legend: True
+        legend_outside: False
+      alpha:
+        display: "$\\phi$"

--- a/tf_pwa/tests/test_full.py
+++ b/tf_pwa/tests/test_full.py
@@ -535,3 +535,26 @@ def test_smear_params(toy_config, fit_result):
         with amp.temp_params(toy_config.gen_smear_params()):
             ret.append(tf.reduce_sum(amp(phsp)).numpy())
     std = np.std(ret)
+
+
+def test_simple_mlp(toy_config):
+    config = ConfigLoader(f"{this_dir}/config_bkg.yml")
+    amp = config.get_amplitude()
+    fcn = config.get_fcn()
+    fcn.nll_grad()
+
+
+def test_add_ref_amp(toy_config):
+    with open(f"{this_dir}/config_cfit.yml") as f:
+        config_dic = yaml.full_load(f)
+    add_ref_amp = {
+        "add_ref_amp": {
+            "config": f"{this_dir}/config_bkg.yml",
+            "params": {},
+            "varname": "bg_value",
+        }
+    }
+    config_dic["preprocessor"] = ["default", add_ref_amp]
+    config = ConfigLoader(config_dic)
+    data = config.get_data("data")[0]
+    assert "bg_value" in data

--- a/tf_pwa/tests/test_full.py
+++ b/tf_pwa/tests/test_full.py
@@ -554,7 +554,7 @@ def test_add_ref_amp(toy_config):
             "varname": "bg_value",
         }
     }
-    config_dic["preprocessor"] = ["default", add_ref_amp]
+    config_dic["data"]["preprocessor"] = ["default", add_ref_amp]
     config = ConfigLoader(config_dic)
     data = config.get_data("data")[0]
     assert "bg_value" in data

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -47,3 +47,8 @@ A \rightarrow R_{CD} B, R_{CD} \rightarrow C D.
 5. [cal_fitfracs.py](cal_fitfracs.py)
 
    Using `python cal_fitfracs.py`, we can get the fit fractions of the fit.
+
+6. [save_amp.py](save_amp.py)
+
+   Using `python save_amp.py --input_file phsp --save_file amp.dat`, we can
+   save amplitude square value to files.

--- a/tutorials/save_amp.py
+++ b/tutorials/save_amp.py
@@ -1,0 +1,62 @@
+import os.path
+import sys
+
+this_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, this_dir + "/..")
+
+
+def main():
+    """Calculate errors of a given set of parameters and their correlation coefficients."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="calculate errors of a given set of parameters and their correlation coefficients"
+    )
+    parser.add_argument(
+        "--params", default="final_params.json", dest="params_file"
+    )
+    parser.add_argument("--input_file", default="data,phsp", dest="input_file")
+    parser.add_argument("--save_file", default="amp.dat", dest="save_file")
+    parser.add_argument(
+        "--save_complex",
+        action="store_true",
+        default=False,
+        dest="save_complex",
+    )
+
+    results = parser.parse_args()
+
+    save_amp(
+        params_file=results.params_file,
+        input_file=results.input_file,
+        save_file=results.save_file,
+        save_complex=results.save_complex,
+    )
+
+
+def save_amp(params_file, input_file, save_file, save_complex):
+    # import tf_pwa
+    import numpy as np
+
+    from tf_pwa.config_loader import ConfigLoader
+
+    config = ConfigLoader("config.yml")
+    config.set_params(params_file)
+    if save_complex:
+        amp = config.get_amplitude().decay_group.get_amp3
+    else:
+        amp = config.get_amplitude()
+
+    for file_i in input_file.strip().split(","):
+        data = config.get_data(file_i)
+        for idx, data_i in enumerate(data):
+            w = amp(data_i).numpy()
+            if save_file.endswith(".npy"):
+                np.save(f"{file_i}{idx}_" + save_file, w)
+            else:
+                w = np.reshape(w, (w.shape[0], -1))
+                np.savetxt(f"{file_i}{idx}_" + save_file, w)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Amplitude model `simple_mlp` , it can be used as background model using MLP (multi-layer perceptron).
```
data:
    extended:   True  # add this since MLP do not have fixed 1 for normalization.
    amp_model:
        simple_mlp:
            n_hidden: [10, 10]  # hidden size of MLP
```

- Preprocessor `add_ref_amp`, can add variable to data.
```
data:
    preprocessor:
        -  default
        - add_ref_amp:
               config: config_bkg.yml   # file name 
               params: params_bkg.json # parameters
               varname: bg_value   # variable  name in data
```
- Simple script to save amplitude square value to file in tutorials.
- support force dtype of extra_var 