### PR TITLE
feat: support default plot config

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: 3.11
       - name: Create distribution
         run: python setup.py sdist
       - name: Publish to PyPI

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,11 +40,6 @@ repos:
       - id: nbstripout
         files: ".ipynb"
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 <br>
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jiangyi15/tf-pwa/HEAD)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen)](https://github.com/pre-commit/pre-commit)
-[![Prettier](https://camo.githubusercontent.com/687a8ae8d15f9409617d2cc5a30292a884f6813a/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f636f64655f7374796c652d70726574746965722d6666363962342e7376673f7374796c653d666c61742d737175617265)](https://prettier.io/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 

--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -1230,7 +1230,6 @@ class PlotParams(dict):
     def __init__(self, plot_config, decay_struct):
         self.decay_struct = decay_struct
         self.config = self.add_predined_vars(plot_config)
-        print(self.config)
         self.defaults_config = {}
         self.defaults_config.update(self.config.get("config", {}))
         chain_map = self.decay_struct.get_chains_map()

--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -87,9 +87,7 @@ class ConfigLoader(BaseConfig):
         self.bound_dic = {}
         self.gauss_constr_dic = {}
         self.init_value = {}
-        self.plot_params = PlotParams(
-            self.config.get("plot", {}), self.decay_struct
-        )
+        self.plot_params = self.create_plot_params()
         self._neglect_when_set_params = []
         self.inv_he = None
         self._Ngroup = 1
@@ -1143,6 +1141,10 @@ class ConfigLoader(BaseConfig):
             module, dir_name, signatures={"serving_default": call}
         )
 
+    def create_plot_params(self):
+        ret = PlotParams(self.config.get("plot", None), self.decay_struct)
+        return ret
+
 
 def set_prefix_constrains(vm, base, params_dic, self):
     prefix = base.get_variable_name()
@@ -1226,10 +1228,11 @@ def validate_file_name(s):
 
 class PlotParams(dict):
     def __init__(self, plot_config, decay_struct):
-        self.config = plot_config
+        self.decay_struct = decay_struct
+        self.config = self.add_predined_vars(plot_config)
+        print(self.config)
         self.defaults_config = {}
         self.defaults_config.update(self.config.get("config", {}))
-        self.decay_struct = decay_struct
         chain_map = self.decay_struct.get_chains_map()
         self.re_map = {}
         for i in chain_map:
@@ -1247,6 +1250,54 @@ class PlotParams(dict):
             self.params.append(i)
         for i in self.get_extra_vars():
             self.params.append(i)
+
+    def add_predined_vars(self, plot_config):
+        if plot_config is None:
+            plot_config = {"predefined": ["mass", "angle"]}
+        plot_config = plot_config.copy()
+        predefined_config = {
+            "mass": self.create_mass_config,
+            "angle": self.create_angle_config,
+        }
+
+        for i in plot_config.get("predefined", []):
+            if i in predefined_config:
+                plot_config[i] = plot_config.get(i, {})
+                tmp = predefined_config[i]()
+                for k, v in tmp.items():
+                    if k not in plot_config:
+                        plot_config[i][k] = v
+            else:
+                warnings.warn("not found such predefined plot config")
+        return plot_config
+
+    def create_mass_config(self):
+        ret = {}
+        for i in self.decay_struct.resonances:
+            chain = self.decay_struct.get_decay_chain(i)
+            finals = chain.sorted_table()[i]
+            name = "".join([getattr(j, "display", str(j)) for j in finals])
+            ret[str(i)] = {"display": "M(" + name + ")"}
+        return ret
+
+    def create_angle_config(self):
+        ret = {}
+        for idx1, chain in enumerate(self.decay_struct):
+            for idx2, decay in enumerate(chain):
+                part = decay.outs[0]
+                prefix = [str(i) for i in chain.inner if i != part]
+                prefix.append(str(part))
+                name = "/".join(prefix)
+                display_sub = getattr(part, "display", str(part))
+                if display_sub[0] == "$" and display_sub[-1] == "$":
+                    display_sub = display_sub[1:-1]
+                display_phi = f"$\\phi_{{{display_sub}}}^{{{idx1}}}$"
+                display_theta = f"$\\cos\\theta_{{{display_sub}}}^{{{idx1}}}$"
+                ret[name] = {
+                    "alpha": {"display": display_phi},
+                    "cos(beta)": {"display": display_theta},
+                }
+        return ret
 
     def get_data_index(self, sub, name, *extra):
         dec = self.decay_struct.topology_structure()

--- a/tf_pwa/config_loader/plot.py
+++ b/tf_pwa/config_loader/plot.py
@@ -1092,7 +1092,7 @@ def _2d_plot_v2(
     color_first=True,
     **kwargs
 ):
-    twodplot = self.config["plot"].get("2Dplot", {})
+    twodplot = self.plot_params.config.get("2Dplot", {})
     new_plot = {}
     for k, v in twodplot.items():
         if "&" in k:
@@ -1172,7 +1172,7 @@ def _2d_plot_v2(
             plt.scatter(data_1[cut], data_2[cut], s=1, alpha=0.8, label="data")
             plot_axis()
             plt.title(title, fontsize="xx-large")
-            plt.savefig(prefix + k + "_data")
+            plt.savefig(prefix + k + "_data." + format)
             plt.clf()
             print("Finish plotting 2D data " + prefix + k)
         if "data_hist" in plot_figs:
@@ -1187,7 +1187,7 @@ def _2d_plot_v2(
             plot_axis()
             plt.title(title, fontsize="xx-large")
             plt.colorbar()
-            plt.savefig(prefix + k + "_data_hist")
+            plt.savefig(prefix + k + "_data_hist." + format)
             plt.clf()
             print("Finish plotting 2D data_hist " + prefix + k)
         # sideband
@@ -1200,7 +1200,7 @@ def _2d_plot_v2(
                 )
                 plot_axis()
                 plt.title(title, fontsize="xx-large")
-                plt.savefig(prefix + k + "_bkg")
+                plt.savefig(prefix + k + "_bkg." + format)
                 plt.clf()
                 print("Finish plotting 2D sideband " + prefix + k)
             else:
@@ -1221,7 +1221,7 @@ def _2d_plot_v2(
                 plot_axis()
                 plt.title(title, fontsize="xx-large")
                 plt.colorbar()
-                plt.savefig(prefix + k + "_bkg_hist")
+                plt.savefig(prefix + k + "_bkg_his." + format)
                 plt.clf()
                 print("Finish plotting 2D sideband histogram " + prefix + k)
             else:
@@ -1240,7 +1240,7 @@ def _2d_plot_v2(
             plot_axis()
             plt.title(title, fontsize="xx-large")
             plt.colorbar()
-            plt.savefig(prefix + k + "_fitted")
+            plt.savefig(prefix + k + "_fitted." + format)
             plt.clf()
             print("Finish plotting 2D fitted " + prefix + k)
         if "pull" in plot_figs:
@@ -1261,7 +1261,7 @@ def _2d_plot_v2(
                 scatter_style=pull_scatter_style,
             )
             plot_axis()
-            plt.savefig(prefix + k + "_pull")
+            plt.savefig(prefix + k + "_pull." + format)
             plt.clf()
             print("Finish plotting 2D pull " + prefix + k)
 

--- a/tf_pwa/tests/config_cfit.yml
+++ b/tf_pwa/tests/config_cfit.yml
@@ -60,6 +60,14 @@ plot:
     dalitz_12:
       x: m_R_BC**2
       y: m_R_BD**2
+    dalitz_12_2:
+      x: m_R_BC**2
+      y: m_R_BD**2
+      add_dalitz_boundary: [R_BC, R_BD]
+    dalitz_12_3:
+      x: m_R_BC**2
+      y: m_R_BD**2
+      add_dalitz_boundary: [4.6, 2.01028, 2.00698, 0.13957]
     mass_angle:
       x: m1
       y: costheta

--- a/tf_pwa/tests/config_plot2.yml
+++ b/tf_pwa/tests/config_plot2.yml
@@ -36,6 +36,8 @@ constrains:
   decay: null
 
 plot:
+  config:
+    yscale: log
   mass:
     R_BC: { display: "$M_{BC}$" }
     R_BD: { display: "$M_{BD}$" }

--- a/tf_pwa/tests/config_toy2.yml
+++ b/tf_pwa/tests/config_toy2.yml
@@ -24,7 +24,7 @@ particle:
   $top:
     A: { J: 1, P: -1, spins: [-1, 1], mass: 4.6 }
   $finals:
-    B: { J: 1, P: -1, mass: 2.00698 }
+    B: { J: 1, P: -1, mass: 2.00698, "display": "$B$"}
     C: { J: 1, P: -1, mass: 2.01028 }
     D: { J: 0, P: -1, mass: 0.13957 }
   R_BC: { J: 1, Par: 1, m0: 4.16, g0: 0.1 }

--- a/tf_pwa/tests/config_toy2.yml
+++ b/tf_pwa/tests/config_toy2.yml
@@ -40,11 +40,3 @@ constrains:
       model: linear
       k: 1.0
       b: 0.01
-
-plot:
-  config:
-    yscale: log
-  mass:
-    R_BC: { display: "$M_{BC}$" }
-    R_BD: { display: "$M_{BD}$" }
-    R_CD: { display: "$M_{CD}$" }


### PR DESCRIPTION
When plot is not included in config.yml, default plot config will be used. Mass and angle will plot by default. 


new option `add_dalitz_boundary` for 2Dplot:
```
plot:
    2Dplot:
        dalitzplot1:
             x: m_R_BC**2
             y: m_R_CD**2
             add_dalitz_boundary: [ R_BC,  R_CD ]
             # dalitz_boundary_style: {"color": "gray", "alpha": 0.5, "zorder": -10} # style of it 
             # add_dalitz_boundary: [4.6, 2.01028, 2.00698, 0.13957]  # or use mass x: s12, y: s23
```