### PR TITLE
Fix: AbsParameterGenerator fails to generate random numbers within bound 

### DIFF
--- a/tf_pwa/variable.py
+++ b/tf_pwa/variable.py
@@ -33,6 +33,7 @@ class AbsParameterGenerator(metaclass=abc.ABCMeta):
                 continue
             if b is not None and x > b:
                 continue
+            return x
         return x
 
 


### PR DESCRIPTION
Description:
This PR fixes an issue in the AbsParameterGenerator class where it could potentially get stuck in an infinite loop when attempting to generate random numbers within a specified range [a,b], eventually reaching the maximum loop iteration limit and failing to properly initialize parameters with random numbers within the given range.

Changes:
Added a return x statement in the force_in_range method when a valid value (within the range) is found