### PR TITLE
feat: prodpdf when amp_model is dict with multiply item

### DIFF
--- a/tf_pwa/tests/config_bkg.yml
+++ b/tf_pwa/tests/config_bkg.yml
@@ -6,6 +6,7 @@ data:
   amp_model:
     simple_mlp:
       n_hidden: [5, 3]
+    constant: {}
 
 decay:
   A:

--- a/tf_pwa/tests/test_full.py
+++ b/tf_pwa/tests/test_full.py
@@ -542,6 +542,7 @@ def test_simple_mlp(toy_config):
     amp = config.get_amplitude()
     fcn = config.get_fcn()
     fcn.nll_grad()
+    amp.partial_weight(config.get_data("phsp")[0])
 
 
 def test_add_ref_amp(toy_config):


### PR DESCRIPTION
When amp_model is dict
```
data:
    amp_model:
            default: {}
            model2: {}
```
then the total model is the production of two models.
