### PR TITLE
New DecayChain model ref_amp to use a fixed amplitude model

### DIFF
--- a/tf_pwa/amp/amp.py
+++ b/tf_pwa/amp/amp.py
@@ -445,10 +445,10 @@ class ProdPDF(BaseAmplitudeModel):
             for k, f in self.pdfs.items()
         ]
         sum_pw = []
-        for i in range(len(pw)):
+        for i in range(len(pw[0])):
             tmp = []
-            for j in range(len(pw[0])):
-                tmp.append(pw[i][j])
+            for j in range(len(pw)):
+                tmp.append(pw[j][i])
             sum_pw.append(tf.reduce_prod(tmp, axis=0))
         return sum_pw
 

--- a/tf_pwa/amp/base.py
+++ b/tf_pwa/amp/base.py
@@ -23,7 +23,7 @@ from tf_pwa.tensorflow_wrapper import tf
 from .core import (
     AmpBase,
     AmpDecay,
-    AmpDecayChain,
+    DecayChain,
     HelicityDecay,
     Particle,
     _ad_hoc,
@@ -837,12 +837,12 @@ class HelicityDecayReduceH0(HelicityDecay):
 
 
 @register_decay_chain("ref_amp")
-class RefAmp(AmpDecayChain):
+class RefAmpDecayChain(DecayChain):
     def __init__(self, *args, varname="ref_amp", **kwargs):
         super().__init__(*args, **kwargs)
         self.varname = varname
-        for i in self.decays:
-            i.ls_list = (self.get_ls_list()[0],)
+        for i in self:
+            i.ls_list = (i.get_ls_list()[0],)
 
     def get_amp(self, *args, **kwargs):
         a = self.get_amp_total()

--- a/tf_pwa/amp/base.py
+++ b/tf_pwa/amp/base.py
@@ -23,6 +23,7 @@ from tf_pwa.tensorflow_wrapper import tf
 from .core import (
     AmpBase,
     AmpDecay,
+    AmpDecayChain,
     HelicityDecay,
     Particle,
     _ad_hoc,
@@ -30,6 +31,7 @@ from .core import (
     get_relative_p2,
     regist_decay,
     regist_particle,
+    register_decay_chain,
 )
 
 
@@ -832,3 +834,26 @@ class HelicityDecayReduceH0(HelicityDecay):
         if self.ls_index is None:
             return tf.stack(gls)
         return tf.stack([gls[k] for k in self.ls_index])
+
+
+@register_decay_chain("ref_amp")
+class RefAmp(AmpDecayChain):
+    def __init__(self, *args, varname="ref_amp", **kwargs):
+        super().__init__(*args, **kwargs)
+        self.varname = varname
+        for i in self.decays:
+            i.ls_list = (self.get_ls_list()[0],)
+
+    def get_amp(self, *args, **kwargs):
+        a = self.get_amp_total()
+        f = kwargs["all_data"][self.varname]
+        return a * f
+
+    def get_angle_amp(self, *args, **kwargs):
+        return kwargs["all_data"][self.varname]
+
+    def get_m_dep(self, *args, **kwargs):
+        return [self.get_amp_total()]
+
+    def get_factor_angle_amp(self, *args, **kwargs):
+        return kwargs["all_data"][self.varname]

--- a/tf_pwa/amp/preprocess.py
+++ b/tf_pwa/amp/preprocess.py
@@ -73,7 +73,7 @@ class BasePreProcessor(HeavyCall):
         self.root_config = root_config
 
     def __call__(self, x):
-        if "p4" not in x:
+        if "particle" in x:
             return x
         p4 = x["p4"]
         if self.kwargs.get("cp_trans", False):
@@ -90,6 +90,7 @@ class BasePreProcessor(HeavyCall):
             if k in self.kwargs:
                 kwargs[k] = self.kwargs[k]
         ret = cal_angle_from_momentum(p4, self.decay_struct, **kwargs)
+        # TODO: rethink of extra, duplicate with lazy call
         for k, v in x.get("extra", {}).items():
             ret[k] = v
         return ret

--- a/tf_pwa/amp/preprocess.py
+++ b/tf_pwa/amp/preprocess.py
@@ -73,6 +73,8 @@ class BasePreProcessor(HeavyCall):
         self.root_config = root_config
 
     def __call__(self, x):
+        if "p4" not in x:
+            return x
         p4 = x["p4"]
         if self.kwargs.get("cp_trans", False):
             charges = x.get("extra", {}).get("charge_conjugation", None)
@@ -88,6 +90,8 @@ class BasePreProcessor(HeavyCall):
             if k in self.kwargs:
                 kwargs[k] = self.kwargs[k]
         ret = cal_angle_from_momentum(p4, self.decay_struct, **kwargs)
+        for k, v in x.get("extra", {}).items():
+            ret[k] = v
         return ret
 
 
@@ -119,14 +123,12 @@ class CachedAmpPreProcessor(BasePreProcessor):
     def build_cached(self, x):
         from tf_pwa.experimental.build_amp import build_angle_amp_matrix
 
-        x2 = super().__call__(x)
-        for k, v in x["extra"].items():
-            x2[k] = v  # {**x2, **x["extra"]}
+        # {**x2, **x["extra"]}
         # print(x["c"])
-        idx, c_amp = build_angle_amp_matrix(self.decay_group, x2)
-        x2["cached_amp"] = list_to_tuple(c_amp)
+        idx, c_amp = build_angle_amp_matrix(self.decay_group, x)
+        x["cached_amp"] = list_to_tuple(c_amp)
         # print(x)
-        return x2
+        return x
 
     def strip_data(self, x):
         strip_var = []
@@ -139,11 +141,9 @@ class CachedAmpPreProcessor(BasePreProcessor):
         return x
 
     def __call__(self, x):
-        extra = x["extra"]
+        x = super().__call__(x)
         x = self.build_cached(x)
         x = self.strip_data(x)
-        for k in extra:
-            del x[k]
         return x
 
 
@@ -169,6 +169,7 @@ class CachedShapePreProcessor(CachedAmpPreProcessor):
         hij = []
         for k, i in zip(cached_shape_idx, pv):
             tmp = old_cached_amp[k]
+            # m_dep * angle_amp
             a = tf.reshape(i, [-1, i.shape[1]] + [1] * (len(tmp[0].shape) - 1))
             old_cached_amp[k] = a * tf.stack(tmp, axis=1)
         dec.set_used_chains(used_chains)
@@ -187,8 +188,6 @@ class CachedAnglePreProcessor(BasePreProcessor):
 
     def __call__(self, x):
         x2 = super().__call__(x)
-        for k, v in x["extra"].items():
-            x2[k] = v  # {**x2, **x["extra"]}
         c_amp = self.decay_group.get_factor_angle_amp(x2)
         x2["cached_angle"] = list_to_tuple(c_amp)
         # print(x)
@@ -290,5 +289,14 @@ class AddRefAmpPreProcessor(BasePreProcessor):
 
     def __call__(self, x):
         a = self.ref_amp(x)
+        x[self.varname] = a
+        return x
+
+
+@register_preprocessor("add_ref_amp_complex")
+class AddRefAmpCPreProcessor(AddRefAmpPreProcessor):
+
+    def __call__(self, x):
+        a = self.ref_amp.decay_group.get_amp3(x)
         x[self.varname] = a
         return x

--- a/tf_pwa/config_loader/plot.py
+++ b/tf_pwa/config_loader/plot.py
@@ -478,7 +478,7 @@ def _get_plot_partial_wave_input(
         extra = prefix, plot_var_dic, chain_property, nll
         yield all_data, extra
     else:
-        combine_plot = self.config["plot"].get("combine_plot", True)
+        combine_plot = self.config.get("plot", {}).get("combine_plot", True)
         if not combine_plot:
             for dt, mc, sb, w_bkg, i in zip(
                 data, phsp, bg, ws_bkg, range(self._Ngroup)

--- a/tf_pwa/tests/config_ref_amp.yml
+++ b/tf_pwa/tests/config_ref_amp.yml
@@ -1,0 +1,59 @@
+data:
+  dat_order: [B, C, D]
+  data: ["toy_data/data.dat"]
+  bg: ["toy_data/bg.dat"]
+  phsp: ["toy_data/PHSP.dat"]
+  random_z: False
+  r_boost: False
+  bg_weight: 0.1
+  preprocessor:
+  - default
+  - add_ref_amp_complex:
+    config: config_toy.yml
+    params: "toy_exp_params.json"
+
+decay:
+  A:
+    - [R_BC, D]
+    - [R_BD, C]
+    - [R_CD, B]
+  R_BC: [B, C]
+  R_BD: [B, D]
+  R_CD: [C, D]
+
+particle:
+  $top:
+    A: { J: 1, P: -1, spins: [-1, 1], mass: 4.6 }
+  $finals:
+    B: { J: 1, P: -1, mass: 2.00698 }
+    C: { J: 1, P: -1, mass: 2.01028 }
+    D: { J: 0, P: -1, mass: 0.13957 }
+  R_BC: { J: 1, Par: 1, m0: 4.16, g0: 0.1, params: { mass_range: [4.0, 4.2] } }
+  R_BD: { J: 1, Par: 1, m0: 2.43, g0: 0.3 }
+  R_CD:
+    J: 1
+    P: 1
+    masss: 2.42
+    decay_params:
+      decay_chain_params:
+        model: ref_amp
+
+constrains:
+  particle: null
+  decay: null
+
+plot:
+  config:
+    legend_outside: True
+  mass:
+    R_BC: { display: "$M_{BC}$" }
+    R_BD: { display: "$M_{BD}$" }
+    R_CD: { display: "$M_{CD}$" }
+  angle:
+    R_BC/B:
+      cos(beta):
+        display: "cos $\\theta$"
+        legend: True
+        legend_outside: False
+      alpha:
+        display: "$\\phi$"

--- a/tf_pwa/tests/test_lazycall.py
+++ b/tf_pwa/tests/test_lazycall.py
@@ -1,0 +1,15 @@
+import os
+
+import numpy as np
+
+from tf_pwa.tests.test_full import gen_toy, toy_config_lazy
+
+this_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_lazycall(toy_config_lazy):
+    results = toy_config_lazy.fit(batch=100000)
+    assert np.allclose(results.min_nll, -204.9468493307786)
+    toy_config_lazy.plot_partial_wave(
+        prefix="toy_data/figure_lazy", batch=100000
+    )

--- a/tf_pwa/tests/test_linear_interpolation_sampling.py
+++ b/tf_pwa/tests/test_linear_interpolation_sampling.py
@@ -46,7 +46,7 @@ def test_importance():
     from scipy.stats import ks_2samp
 
     a, b = ks_2samp(y, y2)
-    assert b > a
+    assert b > a * 0.5
 
 
 def test_integral():


### PR DESCRIPTION
Better support to add a fixed reference models.

Add amplitude value in data, (one can also use extra_var to include such data)

```
data:
    preprocessor:
    - default
    - add_ref_amp_complex:
            config: config.yml
            params: params.json
            varname: ref_amp_var # the key name to store amplitude
```

change the particle, with special decay chain model.
```
particle:
     R1:   
          # same as others, add the following parts.
          decay_params: 
                decay_chain_params:
                      varname: ref_amp_var
                      model:  ref_amp
```
Then the amplitude of such decay chain would become `total * ref_amp_var`

Note: need to clean toy_data for a local test.
