### PR TITLE
feat: flavour tag models

### DIFF
--- a/tf_pwa/amp/time_dep.py
+++ b/tf_pwa/amp/time_dep.py
@@ -1,6 +1,10 @@
 import tensorflow as tf
 
-from tf_pwa.amp.amp import BaseAmplitudeModel, register_amp_model
+from tf_pwa.amp.amp import (
+    BaseAmplitudeModel,
+    create_amplitude,
+    register_amp_model,
+)
 from tf_pwa.amp.core import HelicityDecay, register_decay, to_complex
 from tf_pwa.config import get_config
 from tf_pwa.data import data_shape
@@ -340,6 +344,122 @@ class TimeDepCpFSAmplitudeModel(TimeDepParamsFSAmplitudeModel):
         A = self.decay_group.get_amp(data)
         Abar = self.decay_group.get_amp(data["cp_swap"])
         return A, Abar
+
+
+@register_amp_model("flavour_tag")
+class FlavourTagPDF(BaseAmplitudeModel):
+    def __init__(
+        self,
+        *args,
+        eta_name="eta",
+        tag_name="tag_value",
+        true_tag="tag",
+        tag_eff=1.0,
+        **kwargs,
+    ):
+        self.eta_name = eta_name
+        self.tag_name = tag_name
+        self.true_tag = true_tag
+        self.tag_eff = tag_eff
+        super().__init__(*args, **kwargs)
+
+    def pdf(self, data):
+        eta = data.get(self.eta_name, 0.0)
+        tag_value = data.get(self.tag_name, 1)
+        true_tag = data.get(self.true_tag, 1)
+        tag1, tag2 = eta, eta
+        return tf.where(
+            true_tag > 0,
+            tf.where(
+                tag_value == 0,
+                tf.ones_like(tag1) * (1 - self.tag_eff),
+                tf.where(tag_value > 0, 1 - tag1, tag1) * self.tag_eff,
+            ),
+            tf.where(
+                tag_value == 0,
+                tf.ones_like(tag2) * (1 - self.tag_eff),
+                tf.where(tag_value > 0, tag2, 1 - tag2) * self.tag_eff,
+            ),
+        )
+
+
+@register_amp_model("flavour_tag_linear")
+class FlavourTagLinearPDF(BaseAmplitudeModel):
+    def __init__(
+        self,
+        *args,
+        eta_name="eta",
+        eta_mean=[0.5, 0.5],
+        tag_name="tag_value",
+        true_tag="tag",
+        tag_eff=[1.0, 1.0],
+        **kwargs,
+    ):
+        self.eta_name = eta_name
+        self.tag_name = tag_name
+        self.true_tag = true_tag
+        self.eta_mean = eta_mean
+        self.tag_eff = tag_eff
+        super().__init__(*args, **kwargs)
+
+    def init_params(self, *args, **kwargs):
+        super().init_params(*args, **kwargs)
+        self.top = self.decay_group.top
+        self.top.p0 = self.top.add_var("p0", value=self.eta_mean[0])
+        self.top.p1 = self.top.add_var("p1", value=1.0)
+        self.top.p0bar = self.top.add_var("p0bar", value=self.eta_mean[1])
+        self.top.p1bar = self.top.add_var("p1bar", value=1.0)
+
+    def pdf(self, data):
+        eta = data.get(self.eta_name, 0.0)
+        true_tag = data.get(self.true_tag, 1)
+        tag_value = data.get(self.tag_name, true_tag)
+        tag1 = self.top.p0() + self.top.p1() * (eta - self.eta_mean[0])
+        tag2 = self.top.p0bar() + self.top.p1bar() * (eta - self.eta_mean[1])
+        return tf.where(
+            true_tag > 0,
+            tf.where(
+                tag_value == 0,
+                tf.ones_like(tag1) * (1 - self.tag_eff[0]),
+                tf.where(tag_value > 0, 1 - tag1, tag1) * self.tag_eff[0],
+            ),
+            tf.where(
+                tag_value == 0,
+                tf.ones_like(tag2) * (1 - self.tag_eff[1]),
+                tf.where(tag_value > 0, tag2, 1 - tag2) * self.tag_eff[1],
+            ),
+        )
+
+
+@register_amp_model("flavour_tag_mix")
+class TimeDepFTPDF(BaseAmplitudeModel):
+    def __init__(
+        self,
+        decay_group,
+        base_model={"model": "default"},
+        flavour_tag={"model": "flavour_tag"},
+        **kwargs,
+    ):
+        self.base_model = create_amplitude(decay_group, **base_model)
+        self.flavour_tag = create_amplitude(decay_group, **flavour_tag)
+        super().__init__(decay_group, **kwargs)
+
+    def init_params(self, *args, **kwargs):
+        super().init_params(*args, **kwargs)
+        self.base_model.init_params(*args, **kwargs)
+        self.flavour_tag.init_params(*args, **kwargs)
+
+    def pdf(self, data):
+        time = data["time"]
+        tag = tf.ones_like(time)
+        data["tag"] = tag
+        amp1 = self.base_model(data)
+        ft1 = self.flavour_tag(data)
+        data["tag"] = -tag
+        amp2 = self.base_model(data)
+        ft2 = self.flavour_tag(data)
+        del data["tag"]
+        return amp1 * ft1 + amp2 * ft2
 
 
 def fix_cp_params(config, r1, r2):

--- a/tf_pwa/tests/config_time_dep_ft.yml
+++ b/tf_pwa/tests/config_time_dep_ft.yml
@@ -1,0 +1,57 @@
+data:
+  dat_order: [B, C, D]
+  extra_var:
+    time:
+      default: 0
+      low: 0.0
+      high: 10.0
+      model: uniform
+    tag_value:
+      a: [-1, 1]
+      default: 1
+      model: choice
+    eta:
+      default: 0.5
+      low: 0.0
+      high: 0.5
+      model: uniform
+  cp_particles: [[B, C]]
+  amp_model:
+    flavour_tag_mix:
+      base_model:
+        model: time_dep_cp
+
+decay:
+  A:
+    - [R_BC, D]
+    - [R_BD, C]
+    - [R_CD, B]
+  R_BC: [B, C]
+  R_BD: [B, D]
+  R_CD: [C, D]
+
+particle:
+  $top:
+    A: { J: 0, P: -1, mass: 5.2 }
+  $finals:
+    B: { J: 0, P: -1, mass: 0.13957 }
+    C: { J: 0, P: -1, mass: 0.13957 }
+    D: { J: 0, P: -1, mass: 1.86 }
+  R_BC: { J: 1, P: -1, mass: 1.0, width: 0.1 }
+  R_BD: { J: 1, P: -1, mass: 2.42, width: 0.03 }
+  R_CD: { J: 1, P: -1, mass: 2.42, width: 0.03 }
+
+constrains:
+  particle: null
+  decay: null
+
+plot:
+  config:
+    legend_outside: True
+  mass:
+    R_BC: { display: "$M_{BC}$" }
+    R_BD: { display: "$M_{BD}$" }
+    R_CD: { display: "$M_{CD}$" }
+  index:
+    time: { display: "time", range: [0, 10] }
+    tag: { display: "tag_value" }

--- a/tf_pwa/tests/test_time_dep.py
+++ b/tf_pwa/tests/test_time_dep.py
@@ -88,3 +88,26 @@ def test_time_dep_fs():
     c = amp2(phsp2).numpy()
 
     assert np.allclose(a, c)
+
+
+def test_time_dep_flavour_tag():
+    with open(f"{this_dir}/config_time_dep_ft.yml") as f:
+        config_dic = yaml.full_load(f)
+    config = ConfigLoader(config_dic)
+    amp = config.get_amplitude()
+    phsp = config.generate_phsp(10)
+
+    a = amp(phsp).numpy()
+
+
+def test_time_dep_flavour_tag_linear():
+    with open(f"{this_dir}/config_time_dep_ft.yml") as f:
+        config_dic = yaml.full_load(f)
+    config_dic["data"]["amp_model"]["flavour_tag_mix"]["flavour_tag"] = {
+        "model": "flavour_tag_linear"
+    }
+    config = ConfigLoader(config_dic)
+    amp = config.get_amplitude()
+    phsp = config.generate_phsp(10)
+
+    a = amp(phsp).numpy()

--- a/tf_pwa/tests/test_time_dep.py
+++ b/tf_pwa/tests/test_time_dep.py
@@ -103,9 +103,9 @@ def test_time_dep_flavour_tag():
 def test_time_dep_flavour_tag_linear():
     with open(f"{this_dir}/config_time_dep_ft.yml") as f:
         config_dic = yaml.full_load(f)
-    config_dic["data"]["amp_model"]["flavour_tag_mix"]["flavour_tag"] = {
-        "model": "flavour_tag_linear"
-    }
+    config_dic["data"]["amp_model"]["flavour_tag_mix"]["taggers"] = [
+        {"model": "flavour_tag_linear"}
+    ]
     config = ConfigLoader(config_dic)
     amp = config.get_amplitude()
     phsp = config.generate_phsp(10)


### PR DESCRIPTION
flavour tag model

```
data:
    dat_order: [B, C, D]
    extra_var:
        time:
            default: 0
            low: 0.0
            high: 10.0
            model: uniform
        tag_value:
           a: [-1, 1]
           default: 1
           model: choice
        eta:
           default: 0.5
           low: 0.0
           high: 0.5
           model: uniform   
        tag_value2:
           a: [-1, 1]
           default: 1
           model: choice
        eta2:
           default: 0.5
           low: 0.0
           high: 0.5
           model: uniform  
    cp_particles: [[B, C]]
    amp_model:
        flavour_tag_mix:
            base_model:
                model: time_dep_cp
            taggers:
            - model: flavour_tag
            - model: flavour_tag
              eta_name: eta2
              tag_name: tag_value2
```
combine  `base_model` and `flavour_tag` with `base_model(1)flavour_tag(1) + base_model(-1)flavour_tag(-1)`.
  