### PR TITLE
Remove float conversion to allow JIT

### DIFF
--- a/tf_pwa/model/model.py
+++ b/tf_pwa/model/model.py
@@ -1261,7 +1261,7 @@ class FCN(object):
         constr = self.gauss_constr.get_constrain_term()
         constr_grad = self.gauss_constr.get_constrain_grad()
         self.cached_nll = nll + constr
-        return self.cached_nll, g + constr_grad
+        return tf.reshape(self.cached_nll, ()), g + constr_grad
 
     def get_nll_grad_hessian(self, x={}, batch=None):
         """

--- a/tf_pwa/model/model.py
+++ b/tf_pwa/model/model.py
@@ -1261,7 +1261,7 @@ class FCN(object):
         constr = self.gauss_constr.get_constrain_term()
         constr_grad = self.gauss_constr.get_constrain_grad()
         self.cached_nll = nll + constr
-        return float(self.cached_nll), g + constr_grad
+        return self.cached_nll, g + constr_grad
 
     def get_nll_grad_hessian(self, x={}, batch=None):
         """


### PR DESCRIPTION
This is probably unnecessary: a tensor acts already like a float. Removing the conversion allows the function to be jitted and speed things up