### PR TITLE
use data_mass for generate data

### DIFF
--- a/tf_pwa/amp/amp.py
+++ b/tf_pwa/amp/amp.py
@@ -159,8 +159,8 @@ class BaseAmplitudeModel(AbsPDF):
         self.decay_group.set_used_res(res)
 
     @contextlib.contextmanager
-    def temp_used_res(self, res):
-        with self.decay_group.temp_used_res(res):
+    def temp_used_res(self, res, only=False):
+        with self.decay_group.temp_used_res(res, only=only):
             yield
 
     def set_used_chains(self, used_chains):

--- a/tf_pwa/amp/core.py
+++ b/tf_pwa/amp/core.py
@@ -435,6 +435,11 @@ class Particle(BaseParticle, AmpBase):
     def amp_shape(self):
         return ()
 
+    def get_data_mass(self):
+        if hasattr(self, "data_mass"):
+            return self.data_mass
+        return self.get_mass()
+
     def get_mass(self):
         if self.mass is None:
             warnings.warn(
@@ -2093,9 +2098,9 @@ class DecayGroup(BaseDecayGroup, AmpBase):
         self.add_used_chains(idx_chains)
 
     @contextlib.contextmanager
-    def temp_used_res(self, res):
+    def temp_used_res(self, res, only=False):
         old_idx = self.chains_idx
-        self.set_used_res(res)
+        self.set_used_res(res, only=only)
         yield
         self.chains_idx = old_idx
 

--- a/tf_pwa/amp/core.py
+++ b/tf_pwa/amp/core.py
@@ -381,6 +381,7 @@ class Particle(BaseParticle, AmpBase):
         self.bw_l = bw_l
         self.width_norm = width_norm
         self.params_head = None
+        self.data_mass = None
 
     def init_params(self):
         self.d = 3.0
@@ -436,7 +437,7 @@ class Particle(BaseParticle, AmpBase):
         return ()
 
     def get_data_mass(self):
-        if hasattr(self, "data_mass"):
+        if self.data_mass is not None:
             return self.data_mass
         return self.get_mass()
 

--- a/tf_pwa/config_loader/sample.py
+++ b/tf_pwa/config_loader/sample.py
@@ -293,8 +293,8 @@ def build_phsp_chain(decay_group):
     for i in inner_node[1:]:
         a = a & i
 
-    m0 = decay_group.top.get_mass()
-    mi = [i.get_mass() for i in decay_group.outs]
+    m0 = decay_group.top.get_data_mass()
+    mi = [i.get_data_mass() for i in decay_group.outs]
 
     if any(i is None for i in [m0] + mi):
         raise ValueError("mass required to generate phase space")
@@ -315,7 +315,7 @@ def build_phsp_chain(decay_group):
     nodes = []
     for i in a:
         if get_particle_model_name(decay_map[i]) == "one":
-            nodes.append((i, float(decay_map[i].get_mass())))
+            nodes.append((i, float(decay_map[i].get_data_mass())))
 
     mi = dict(zip(decay_group.outs, mi))
 

--- a/tf_pwa/data_trans/helicity_angle.py
+++ b/tf_pwa/data_trans/helicity_angle.py
@@ -30,7 +30,7 @@ class HelicityAngle1:
         """generate monmentum with M_name = m"""
         m = tf.convert_to_tensor(m, tf.float64)
         ms = [
-            i.core.get_mass() if str(i.core) != str(name) else m
+            i.core.get_data_mass() if str(i.core) != str(name) else m
             for i in self.decay_chain
         ]
         ms.append(self.par[-1].get_mass())
@@ -81,7 +81,9 @@ class HelicityAngle:
                             replace_mass[str(j)], tf.float64
                         )
                     else:
-                        ms[j] = tf.convert_to_tensor(j.get_mass(), tf.float64)
+                        ms[j] = tf.convert_to_tensor(
+                            j.get_data_mass(), tf.float64
+                        )
         return ms
 
     def generate_p_mass(self, name, m, random=False):
@@ -150,13 +152,13 @@ class HelicityAngle:
         high_bound = None
         for i in self.decay_chain:
             if str(i.core) == name:
-                low_bound = sum([j.get_mass() for j in i.outs])
+                low_bound = sum([j.get_data_mass() for j in i.outs])
             if name in [str(j) for j in i.outs]:
                 sum_mass = 0.0
                 for j in i.outs:
                     if str(j) != name:
-                        sum_mass = sum_mass + j.get_mass()
-                high_bound = i.core.get_mass() - sum_mass
+                        sum_mass = sum_mass + j.get_data_mass()
+                high_bound = i.core.get_data_mass() - sum_mass
         return (low_bound, high_bound)
 
     def find_variable(self, dat):

--- a/tf_pwa/tests/test_full.py
+++ b/tf_pwa/tests/test_full.py
@@ -203,9 +203,13 @@ def test_cfit(gen_toy):
 
 def test_sdp_gen(gen_toy):
     config = ConfigLoader(f"{this_dir}/config_cfit.yml")
+    top = config.get_decay().top
     config.generate_SDP_p("R_BC", 10, legacy=True)
     config.generate_SDP("R_BC", 10)
     config.generate_SDP_p("R_BC", 10, legacy=False)
+    top.data_mass = top.get_mass() + 0.1
+    data = config.generate_SDP("R_BC", 10)
+    assert np.allclose(data["particle"][top]["m"], top.data_mass)
 
 
 def test_precached(gen_toy):


### PR DESCRIPTION
Use data_mass to replace mass for Particle in generating data.
So that we can change the mass in data only without affecting model. 

For example integration of Dalitz plot with different center mass
```
from tf_pwa.config_loader import ConfigLoader
from scipy.integrate import quad
import numpy as np
import matplotlib.pyplot as plt

config = ConfigLoader("config.yml")
mb, mc, md = [i.get_mass() for i in config.get_decay().outs]
m_max = 5.2

def p(m0,m1,m2):
     return np.sqrt(np.abs((m0**2-(m1+m2)**2)*(m0**2-(m1-m2)**2)))/2/m0

def rho(m, mbc):
     return p(m, mbc, md)*p(mbc, mb, mc)

def phsp_volume(m):
    return quad(lambda x: rho(m, x), mb+mc, m-md)[0]

m = np.linspace(mb+mc+md+1e-6, m_max)
y = []
for mi in m:
    config.get_decay().top.data_mass = mi
    phsp = config.generate_phsp(10000)
    yi = np.mean(config.get_amplitude()(phsp).numpy()) * phsp_volume(mi)
    y.append(yi)

plt.plot(m, y)
plt.show()
```