### PR TITLE
fixed: width_linear_npy no m0 in imag, add option  width_scale

### DIFF
--- a/tf_pwa/amp/interpolation.py
+++ b/tf_pwa/amp/interpolation.py
@@ -61,8 +61,8 @@ class InterpolationParticle(Particle):
     def get_point_values(self):
         p = self.point_value()
         if self.with_bound:
-            v_r = [tf.math.real(i) for i in p]
-            v_i = [tf.math.imag(i) for i in p]
+            v_r = [tf.math.real(i) for i in tf.unstack(p)]
+            v_i = [tf.math.imag(i) for i in tf.unstack(p)]
         else:
             v_r = [0.0] + [tf.math.real(i) for i in p] + [0.0]
             v_i = [0.0] + [tf.math.imag(i) for i in p] + [0.0]
@@ -101,9 +101,13 @@ def create_width_interp_class(cls):
             g0 = self.get_width()
 
             delta = m0**2 - m**2
-            refm0 = tf.math.real(self.interp(tf.stack([m0])))[0]
+            fm0 = self.interp(tf.stack([m0]))[0]
+            refm0 = tf.math.real(fm0)
+            imfm0 = tf.math.imag(fm0)
+            if getattr(self, "width_scale", False):
+                g0 = g0 / imfm0
             re = delta - m0 * g0 * (tf.math.real(fm) - refm0)
-            im = g0 * tf.math.imag(fm)
+            im = m0 * g0 * tf.math.imag(fm)
             dom = re * re + im * im
             return tf.complex(re / dom, im / dom)
 
@@ -195,6 +199,8 @@ class WidthInterpLinearNpy(create_width_interp_class(InterpLinearNpy)):
     .. math::
 
         f(m) = \\frac{1}{m_0^2 - m^2 - m_0 \\Gamma_0 (Re \\Pi(m) - Re \\Pi(m_0) + i Im \\Pi(m))}
+
+    Additional option `width_scale: True`, will use :math:`\\Pi(m)/Im \\Pi(m_0)` instead of :math:`\\Pi(m)` to have a normal width value.
 
     The example is `exp(5 I m)`.
 

--- a/tf_pwa/amp/interpolation.py
+++ b/tf_pwa/amp/interpolation.py
@@ -214,6 +214,8 @@ class WidthInterpLinearNpy(create_width_interp_class(InterpLinearNpy)):
         >>> mi = m[::5]
         >>> np.savetxt(a, np.stack([mi, np.cos(mi*5), np.sin(mi*5)], axis=-1))
         >>> axs = plot_particle_model("width_linear_txt", {"mass": 0.5, "width": 0.2,"file": a})
+        >>> _ = plot_particle_model("width_linear_txt", {"mass": 0.5, "width": 0.2, "width_scale": True, "file": a}, axis = axs)
+        >>> _ = axs[2].legend(["default", "width_scale=True"])
 
     """
 


### PR DESCRIPTION
In previous, for the model `width_linear_npy` model, the width is g0 * m0, and now it is g0 only.
and new option 
```
width_scale: True
model: width_linear_npy
file: gamma.npy
```
And the the width become the same define and normal BW.
