### PR TITLE
feat: fit with hard constraints

### DIFF
--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -311,6 +311,8 @@ class ConfigLoader(BaseConfig):
         for k, v in dic.items():
             print("variable range: ", k, " in ", v)
             self.bound_dic[k] = v
+        amp.vm.set_bound(self.bound_dic)
+        self.bound_dic = {}
 
     def add_var_equal_constraints(self, amp, dic=None):
         if dic is None:
@@ -784,12 +786,19 @@ class ConfigLoader(BaseConfig):
         callback=None,
         grad_scale=1.0,
         gtol=1e-3,
+        add_fun=None,
+        constraints=None,
     ):
         if data is None and phsp is None:
             data, phsp, bg, inmc = self.get_all_data()
             fcn = self.get_fcn(batch=batch)
         else:
             fcn = self.get_fcn([data, phsp, bg, inmc], batch=batch)
+        if add_fun is not None:
+            from tf_pwa.model.model import AddFCN
+
+            add_fun_obj = fcn.vm.build_nll_grad(add_fun)
+            fcn = AddFCN(fcn, add_fun_obj)
         if self.config["data"].get("lazy_call", False):
             print_init_nll = False
         # print("sss")
@@ -820,6 +829,7 @@ class ConfigLoader(BaseConfig):
             callback=callback,
             grad_scale=grad_scale,
             gtol=gtol,
+            constraints=constraints,
         )
         if self.fit_params.hess_inv is not None:
             self.inv_he = self.fit_params.hess_inv

--- a/tf_pwa/config_loader/config_loader.py
+++ b/tf_pwa/config_loader/config_loader.py
@@ -835,6 +835,46 @@ class ConfigLoader(BaseConfig):
             self.inv_he = self.fit_params.hess_inv
         return self.fit_params
 
+    @time_print
+    def fit_cons(self, fun, val, k=10000, gauss_first=True, **kwargs):
+
+        if gauss_first:
+
+            if hasattr(fun, "nll_grad"):
+
+                def add_fun(*args, **kwargs):
+                    y, g = fun.nll_grad(*args, **kwargs)
+                    return k * (y - val) ** 2, 2 * k * (y - val) * g
+
+                class _Tmp:
+                    pass
+
+                add_fun_obj = _Tmp()
+                add_fun_obj.nll_grad = add_fun
+            else:
+
+                def add_fun_obj(*args, **kwargs):
+                    return k * (fun(*args, **kwargs) - val) ** 2
+
+            self.fit(add_fun=add_fun_obj, **kwargs)
+
+        f1 = self.vm.build_nll_grad(fun)  #  then f1(x) is f(), df/dx (x)
+        f2 = self.vm.trans_fcn_grad(f1)  # to include variables boundary
+        from tf_pwa.fit_improve import Cached_FG
+
+        f3 = Cached_FG(f2)
+        ret = self.fit(
+            constraints=[
+                {
+                    "fun": lambda x: f3(x)[0] - val,
+                    "jac": lambda x: f3(x)[1],
+                    "type": "eq",
+                }
+            ],
+            **kwargs,
+        )
+        return ret
+
     def reinit_params(self):
         vm = self.get_amplitude().vm
         vm.refresh_vars(init_val=self.init_value, bound_dic=self.bound_dic)

--- a/tf_pwa/config_loader/data_root_lhcb.py
+++ b/tf_pwa/config_loader/data_root_lhcb.py
@@ -102,12 +102,13 @@ class RootData(MultiData):
         ):
             expr = self.dic[idx + tail].format(**file_name_part)
             expr = sympy.simplify(expr)
-            var = list(expr.free_symbols)
+            var = [str(i) for i in expr.free_symbols]
             tmp = {}
             custom_function["select"] = lambda x: x[i]
             tmp = load_root_data(
-                file_name.format(**file_name_part), used_vars=var
+                file_name.format(**file_name_part), used_vars=var, is_tree=True
             )
+            print(tmp)
             ret.append(
                 sympy.lambdify(var, expr, modules=[custom_function, "numpy"])(
                     **tmp

--- a/tf_pwa/config_loader/data_root_lhcb.py
+++ b/tf_pwa/config_loader/data_root_lhcb.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 
 from tf_pwa.config_loader.data import MultiData, register_data_mode
 from tf_pwa.data import data_mask
-from tf_pwa.root_io import uproot, uproot_version
+from tf_pwa.root_io import load_root_data, uproot, uproot_version
 
 
 def build_matrix(order, matrix):
@@ -105,13 +105,9 @@ class RootData(MultiData):
             var = list(expr.free_symbols)
             tmp = {}
             custom_function["select"] = lambda x: x[i]
-            with uproot.open(file_name.format(**file_name_part)) as t:
-                for name in var:
-                    b = t.get(str(name))
-                    if b is None:
-                        print("not found", name)
-                        continue
-                    tmp[str(name)] = b.array(library="np")
+            tmp = load_root_data(
+                file_name.format(**file_name_part), used_vars=var
+            )
             ret.append(
                 sympy.lambdify(var, expr, modules=[custom_function, "numpy"])(
                     **tmp

--- a/tf_pwa/config_loader/data_root_lhcb.py
+++ b/tf_pwa/config_loader/data_root_lhcb.py
@@ -127,12 +127,13 @@ class RootData(MultiData):
         scale = self.dic.get("unit_scale", 0.001)
         ret = []
         for file_name_part in build_matrix(matrix_order[:-2], matrix):
-            tmp = []
-            with uproot.open(file_name.format(**file_name_part)) as t:
-                for pname in build_matrix(matrix_order[-3:], matrix):
-                    tmp.append(
-                        t.get(p4_name.format(**pname)).array(library="np")
-                    )
+            pnames = []
+            for pname in build_matrix(matrix_order[-3:], matrix):
+                pnames.append(p4_name.format(**pname))
+            tmp = load_root_data(
+                file_name.format(**file_name_part), pnames, is_tree=True
+            )
+            tmp = [tmp[i] for i in pnames]
             ret.append(
                 scale * np.stack(tmp, axis=-1).reshape((-1, len(tmp) // 4, 4))
             )

--- a/tf_pwa/config_loader/multi_config.py
+++ b/tf_pwa/config_loader/multi_config.py
@@ -209,6 +209,11 @@ class MultiConfig(object):
             self.inv_he = self.fit_params.hess_inv
         return self.fit_params
 
+    def fit_cons(self, fun, val, k=10000, gauss_first=True, **kwargs):
+        return ConfigLoader.fit_cons(
+            self, fun, val, k=10000, gauss_first=True, **kwargs
+        )
+
     def reinit_params(self):
         self.get_amplitudes()[0].vm.refresh_vars(bound_dic=self.bound_dic)
 

--- a/tf_pwa/config_loader/multi_config.py
+++ b/tf_pwa/config_loader/multi_config.py
@@ -183,8 +183,15 @@ class MultiConfig(object):
         maxiter=None,
         print_init_nll=False,
         callback=None,
+        add_fun=None,
+        constraints=None,
     ):
         fcn = self.get_fcn(datas=datas)
+        if add_fun is not None:
+            from tf_pwa.model.model import AddFCN
+
+            add_fun_obj = fcn.vm.build_nll_grad(add_fun)
+            fcn = AddFCN(fcn, add_fun_obj)
         # fcn.gauss_constr.update({"Zc_Xm_width": (0.177, 0.03180001857)})
         print("\n########### initial parameters")
         print(json.dumps(fcn.get_params(), indent=2), flush=True)
@@ -196,6 +203,7 @@ class MultiConfig(object):
             bounds_dict=self.bound_dic,
             maxiter=maxiter,
             callback=callback,
+            constraints=constraints,
         )
         if self.fit_params.hess_inv is not None:
             self.inv_he = self.fit_params.hess_inv

--- a/tf_pwa/fit.py
+++ b/tf_pwa/fit.py
@@ -196,6 +196,7 @@ def fit_scipy(
     standard_complex=True,
     grad_scale=1.0,
     gtol=1e-3,
+    constraints=None,
 ):
     """
 
@@ -285,7 +286,16 @@ def fit_scipy(
                 params, fcn, min_nll, ndf=0, success=True, hess_inv=None
             )
         # s = minimize(f_g, x0, method='trust-constr', jac=True, hess=BFGS(), options={'gtol': 1e-4, 'disp': True})
-        if method == "test":
+        if constraints is not None:
+            s = minimize(
+                f_g,
+                x0,
+                jac=True,
+                constraints=constraints,
+                callback=callback,
+                options={"disp": True},
+            )
+        elif method == "test":
             try:
                 s = my_minimize(
                     f_g,
@@ -351,7 +361,9 @@ def fit_scipy(
         ndf = s.x.shape[0]
         min_nll = s.fun / grad_scale
         success = s.success
-        hess_inv = fcn.vm.trans_error_matrix(s.hess_inv * grad_scale, s.x)
+        hess_inv = None
+        if hasattr(s, "hess_inv"):
+            hess_inv = fcn.vm.trans_error_matrix(s.hess_inv * grad_scale, s.x)
         fcn.vm.remove_bound()
 
         xn = fcn.vm.get_all_val()
@@ -419,7 +431,7 @@ def fit_scipy(
         fcn.vm.standard_complex()
     params = fcn.get_params()  # vm.get_all_dic()
     return FitResult(
-        params, fcn, min_nll, ndf=ndf, success=success, hess_inv=hess_inv
+        params, fcn, min_nll, ndf=ndf, success=bool(success), hess_inv=hess_inv
     )
 
 

--- a/tf_pwa/model/model.py
+++ b/tf_pwa/model/model.py
@@ -1538,3 +1538,24 @@ class MixLogLikehoodFCN(CombineFCN):
             gs.append(g)
         print(sum(nlls))
         return sum(nlls), tf.reduce_sum(gs, axis=0)
+
+
+class AddFCN:
+    def __init__(self, fcn, add):
+        self.fcn = fcn
+        self.vm = fcn.vm
+        self.add = add
+
+    def __call__(self, x={}):
+        y = self.fcn(x)
+        y2, g2 = self.add(x)
+        return y + y2
+
+    def nll_grad(self, x):
+        y, g = self.fcn.nll_grad(x)
+        y2, g2 = self.add(x)
+        self.cached_nll = y + y2
+        return self.cached_nll, g + g2
+
+    def get_params(self):
+        return self.fcn.get_params()

--- a/tf_pwa/root_io.py
+++ b/tf_pwa/root_io.py
@@ -19,7 +19,7 @@ except ImportError as e:
         uproot = None
 
 
-def load_root_data(fnames):
+def load_root_data(fnames, used_vars=None):
     """load root file as dict"""
     if isinstance(fnames, str):
         fnames = [fnames]
@@ -37,7 +37,7 @@ def load_root_data(fnames):
     for i in common_keys:
         data = []
         for j in root_file:
-            data_i = load_Ttree(j.get(i))
+            data_i = load_Ttree(j.get(i), used_vars=used_vars)
             data.append(data_i)
         ret[i] = data_merge(*data)
     for i in root_file:
@@ -45,12 +45,14 @@ def load_root_data(fnames):
     return ret
 
 
-def load_Ttree(tree):
+def load_Ttree(tree, used_vars=None):
     """load TTree as dict"""
     ret = {}
+    if used_vars is None:
+        used_vars = list(tree.keys())
     if uproot_version >= 5:
-        return tree.arrays(tree.keys(), library="np")
-    for i in tree.keys():
+        return tree.arrays(used_vars, library="np")
+    for i in used_vars:
         if uproot_version >= 4:
             arr = tree.get(i).array(library="np")
         else:
@@ -101,7 +103,9 @@ def save_dict_to_root(dic, file_name, tree_name=None):
                 )
                 branch_data[j] = np.array(d[i])
                 branch_type[j] = branch_data[j].dtype.name
-            if uproot_version >= 4:
+            if uproot_version >= 5:
+                f.mktree(t, branch_data)
+            elif uproot_version >= 4:
                 f[t] = branch_data
             else:
                 f[t] = uproot.newtree(branch_type)

--- a/tf_pwa/root_io.py
+++ b/tf_pwa/root_io.py
@@ -111,7 +111,8 @@ def save_dict_to_root(dic, file_name, tree_name=None):
                 branch_type[j] = branch_data[j].dtype.name
             if uproot_version >= 5:
                 f.mktree(t, branch_type)
-            if uproot_version >= 4:
+                f[t].extend(branch_data)
+            elif uproot_version >= 4:
                 f[t] = branch_data
             else:
                 f[t] = uproot.newtree(branch_type)

--- a/tf_pwa/root_io.py
+++ b/tf_pwa/root_io.py
@@ -19,7 +19,7 @@ except ImportError as e:
         uproot = None
 
 
-def load_root_data(fnames, used_vars=None):
+def load_root_data(fnames, used_vars=None, is_tree=False):
     """load root file as dict"""
     if isinstance(fnames, str):
         fnames = [fnames]
@@ -37,9 +37,15 @@ def load_root_data(fnames, used_vars=None):
     for i in common_keys:
         data = []
         for j in root_file:
-            data_i = load_Ttree(j.get(i), used_vars=used_vars)
-            data.append(data_i)
-        ret[i] = data_merge(*data)
+            if is_tree:
+                if i in used_vars:
+                    data_i = load_Ttree(j, used_vars=[i])
+                    data.append(data_i[i])
+            else:
+                data_i = load_Ttree(j.get(i), used_vars=used_vars)
+                data.append(data_i)
+        if data:
+            ret[i] = data_merge(*data)
     for i in root_file:
         i.close()
     return ret
@@ -51,7 +57,7 @@ def load_Ttree(tree, used_vars=None):
     if used_vars is None:
         used_vars = list(tree.keys())
     if uproot_version >= 5:
-        return tree.arrays(used_vars, library="np")
+        return tree.arrays(list(used_vars), library="np")
     for i in used_vars:
         if uproot_version >= 4:
             arr = tree.get(i).array(library="np")
@@ -104,8 +110,8 @@ def save_dict_to_root(dic, file_name, tree_name=None):
                 branch_data[j] = np.array(d[i])
                 branch_type[j] = branch_data[j].dtype.name
             if uproot_version >= 5:
-                f.mktree(t, branch_data)
-            elif uproot_version >= 4:
+                f.mktree(t, branch_type)
+            if uproot_version >= 4:
                 f[t] = branch_data
             else:
                 f[t] = uproot.newtree(branch_type)

--- a/tf_pwa/root_io.py
+++ b/tf_pwa/root_io.py
@@ -48,6 +48,8 @@ def load_root_data(fnames):
 def load_Ttree(tree):
     """load TTree as dict"""
     ret = {}
+    if uproot_version >= 5:
+        return tree.arrays(tree.keys(), library="np")
     for i in tree.keys():
         if uproot_version >= 4:
             arr = tree.get(i).array(library="np")

--- a/tf_pwa/tests/test_full.py
+++ b/tf_pwa/tests/test_full.py
@@ -416,25 +416,25 @@ def test_fit(toy_config, fit_result):
 def test_cons_fit(toy_config, fit_result):
     v = fit_result.params["A->R_CD.BR_CD->C.D_total_0r"]
 
-    def add_fun():
+    def eval_fun():
         a = toy_config.vm.read("A->R_CD.BR_CD->C.D_total_0r")
-        return a - v
+        return a
 
-    ret = toy_config.fit(add_fun=lambda: add_fun() ** 2)
-    from tf_pwa.fit_improve import Cached_FG
+    ret = toy_config.fit_cons(eval_fun, v)
+    assert np.allclose(ret.min_nll, -204.9468493307786)
+    ret = toy_config.fit_cons(eval_fun, v, gauss_first=False)
+    assert np.allclose(ret.min_nll, -204.9468493307786)
 
-    cons_f_g2 = Cached_FG(
-        toy_config.vm.trans_fcn_grad(toy_config.vm.build_nll_grad(add_fun))
-    )
-    ret = toy_config.fit(
-        constraints=[
-            {
-                "fun": lambda x: cons_f_g2(x)[0],
-                "jac": lambda x: cons_f_g2(x)[1],
-                "type": "eq",
-            }
-        ]
-    )
+    eval_fun_grad = toy_config.vm.build_nll_grad(eval_fun)
+
+    class Tmp:
+        pass
+
+    a = Tmp()
+    a.nll_grad = eval_fun_grad
+    ret = toy_config.fit_cons(a, v)
+    assert np.allclose(ret.min_nll, -204.9468493307786)
+    ret = toy_config.fit_cons(a, v, gauss_first=False)
     assert np.allclose(ret.min_nll, -204.9468493307786)
     return ret
 
@@ -478,6 +478,17 @@ def test_fit_combine(toy_config2):
     toy_config2.get_params_error()
     print(toy_config2.get_params())
     toy_config2.plot_partial_wave(results)
+
+
+def test_fit_combine_cons(toy_config2, fit_result):
+    v = fit_result.params["A->R_BD.C_g_ls_2r"]
+
+    def eval_fun():
+        a = toy_config2.vm.read("A->R_BD.C_g_ls_2r")
+        return a
+
+    ret = toy_config2.fit_cons(eval_fun, v)
+    assert np.allclose(ret.min_nll, -204.9468493307786 * 2)
 
 
 def test_plot_combine(gen_toy):

--- a/tf_pwa/tests/test_full.py
+++ b/tf_pwa/tests/test_full.py
@@ -413,6 +413,32 @@ def test_fit(toy_config, fit_result):
     toy_config.attach_fix_params_error({"R_BC_mass": 0.01})
 
 
+def test_cons_fit(toy_config, fit_result):
+    v = fit_result.params["A->R_CD.BR_CD->C.D_total_0r"]
+
+    def add_fun():
+        a = toy_config.vm.read("A->R_CD.BR_CD->C.D_total_0r")
+        return a - v
+
+    ret = toy_config.fit(add_fun=lambda: add_fun() ** 2)
+    from tf_pwa.fit_improve import Cached_FG
+
+    cons_f_g2 = Cached_FG(
+        toy_config.vm.trans_fcn_grad(toy_config.vm.build_nll_grad(add_fun))
+    )
+    ret = toy_config.fit(
+        constraints=[
+            {
+                "fun": lambda x: cons_f_g2(x)[0],
+                "jac": lambda x: cons_f_g2(x)[1],
+                "type": "eq",
+            }
+        ]
+    )
+    assert np.allclose(ret.min_nll, -204.9468493307786)
+    return ret
+
+
 def test_bacth_sum(toy_config, fit_result):
     toy_config.get_params_error(fit_result)
     res = list(range(len(list(toy_config.get_decay()))))

--- a/tf_pwa/variable.py
+++ b/tf_pwa/variable.py
@@ -804,7 +804,7 @@ class VarsManager(object):
                 i += 1
             fcn, grad_yv = fcn_grad(yvals)
             grad = np.array(grad_yv) * dydxs
-            return fcn, grad
+            return float(fcn), grad
 
         return fcn_t
 
@@ -929,6 +929,22 @@ class VarsManager(object):
         self.mask_vars = params
         yield
         self.mask_vars = old_mask
+
+    def build_nll_grad(self, fcn):
+        if hasattr(fcn, "nll_grad"):
+            f = fcn.nll_grad
+        else:
+
+            def f(x, *args, **kwargs):
+                self.set_all(x)
+                with tf.GradientTape() as tape:
+                    y = fcn(*args, **kwargs)
+                g = tape.gradient(
+                    y, self.trainable_variables, unconnected_gradients="zero"
+                )
+                return float(y), np.array([float(i) for i in g])
+
+        return f
 
     def minimize(self, fcn, jac=True, method="BFGS", mini_kwargs={}):
         """


### PR DESCRIPTION
Support Hard constraints of function using constraints fit in [scipy](https://docs.scipy.org/doc/scipy/reference/optimize.minimize-slsqp.html#optimize-minimize-slsqp). 

It could find the  solution that

$$x = \arg\min (-\ln L)  \text{ s.t. }  f(x) = 0.$$

$f(x)$ is a function of fit parameters such as fit fractions.

The code is as 
```
from tf_pwa.fit_improve import Cached_FG

amp = config.get_amplitude()

val = 0.1 

def f():  # example of fit fraction
   a = tf.reduce_sum(amp(phsp_noeff))
   with amp.temp_used_res(["R1"]): 
        b = tf.reduce_sum(amp(phsp_noeff))
   frac = b /a
   return  frac

config.fit_cons(f, val)
```

before the fit, it would be better to find a close solution using soft constraints

See more `test_cons_fit` in  `tests/test_full.py` 